### PR TITLE
API-3471

### DIFF
--- a/app/uk/gov/hmrc/models/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/models/JsonFormatters.scala
@@ -110,28 +110,7 @@ object JsonFormatters {
   implicit val formatApplicationTokens = Json.format[ApplicationTokens]
   implicit val formatSubscriptionData = Json.format[SubscriptionData]
 
-  val applicationDataReads: Reads[ApplicationData] = (
-    (JsPath \ "id").read[UUID] and
-      (JsPath \ "name").read[String] and
-      (JsPath \ "normalisedName").read[String] and
-      (JsPath \ "collaborators").read[Set[Collaborator]] and
-      (JsPath \ "description").readNullable[String] and
-      (JsPath \ "wso2Username").read[String] and
-      (JsPath \ "wso2Password").read[String] and
-      (JsPath \ "wso2ApplicationName").read[String] and
-      (JsPath \ "tokens").read[ApplicationTokens] and
-      (JsPath \ "state").read[ApplicationState] and
-      (JsPath \ "access").read[Access] and
-      (JsPath \ "createdOn").read[DateTime] and
-      (JsPath \ "rateLimitTier").readNullable[RateLimitTier] and
-      (JsPath \ "environment").read[String] and
-      (JsPath \ "checkInformation").readNullable[CheckInformation] and
-      ((JsPath \ "blocked").read[Boolean] or Reads.pure(false))
-    )(ApplicationData.apply _)
-
-  implicit val formatApplicationData = {
-    Format(applicationDataReads, Json.writes[ApplicationData])
-  }
+  implicit val formatApplicationData = Json.format[ApplicationData]
 
   implicit val formatCreateApplicationRequest = Json.format[CreateApplicationRequest]
   implicit val formatUpdateApplicationRequest = Json.format[UpdateApplicationRequest]


### PR DESCRIPTION
Removed json formatter for externally facing domain.

The formatter for the mongo domain ensures we have a boolean value in the blocked flag so we don't need a specific Reads instance for ensuring we send back a boolean as there will always be one.