### PR TITLE
Modified the tests that verify Mongo indexes are applied so that they…

### DIFF
--- a/test/it/uk/gov/hmrc/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/repository/ApplicationRepositorySpec.scala
@@ -440,21 +440,20 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
   "The 'application' collection" should {
     "have all the current indexes" in {
 
-      val indexVersion = Some(1)
       val expectedIndexes = Set(
-        Index(key = Seq("_id" -> Ascending), name = Some("_id_"), unique = false, background = false, version = indexVersion),
-        Index(key = Seq("state.verificationCode" -> Ascending), name = Some("verificationCodeIndex"), background = true, version = indexVersion),
-        Index(key = Seq("state.name" -> Ascending, "state.updatedOn" -> Ascending), name = Some("stateName_stateUpdatedOn_Index"), background = true, version = indexVersion),
-        Index(key = Seq("id" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true, version = indexVersion),
-        Index(key = Seq("normalisedName" -> Ascending), name = Some("applicationNormalisedNameIndex"), background = true, version = indexVersion),
-        Index(key = Seq("tokens.production.clientId" -> Ascending), name = Some("productionTokenClientIdIndex"), unique = true, background = true, version = indexVersion),
-        Index(key = Seq("tokens.sandbox.clientId" -> Ascending), name = Some("sandboxTokenClientIdIndex"), unique = true, background = true, version = indexVersion),
-        Index(key = Seq("access.overrides" -> Ascending), name = Some("accessOverridesIndex"), background = true, version = indexVersion),
-        Index(key = Seq("access.accessType" -> Ascending), name = Some("accessTypeIndex"), background = true, version = indexVersion),
-        Index(key = Seq("collaborators.emailAddress" -> Ascending), name = Some("collaboratorsEmailAddressIndex"), background = true, version = indexVersion)
+        Index(key = Seq("_id" -> Ascending), name = Some("_id_"), unique = false, background = false),
+        Index(key = Seq("state.verificationCode" -> Ascending), name = Some("verificationCodeIndex"), background = true),
+        Index(key = Seq("state.name" -> Ascending, "state.updatedOn" -> Ascending), name = Some("stateName_stateUpdatedOn_Index"), background = true),
+        Index(key = Seq("id" -> Ascending), name = Some("applicationIdIndex"), unique = true, background = true),
+        Index(key = Seq("normalisedName" -> Ascending), name = Some("applicationNormalisedNameIndex"), background = true),
+        Index(key = Seq("tokens.production.clientId" -> Ascending), name = Some("productionTokenClientIdIndex"), unique = true, background = true),
+        Index(key = Seq("tokens.sandbox.clientId" -> Ascending), name = Some("sandboxTokenClientIdIndex"), unique = true, background = true),
+        Index(key = Seq("access.overrides" -> Ascending), name = Some("accessOverridesIndex"), background = true),
+        Index(key = Seq("access.accessType" -> Ascending), name = Some("accessTypeIndex"), background = true),
+        Index(key = Seq("collaborators.emailAddress" -> Ascending), name = Some("collaboratorsEmailAddressIndex"), background = true)
       )
 
-      verifyIndexes(applicationRepository, expectedIndexes)
+      verifyIndexesVersionAgnostic(applicationRepository, expectedIndexes)
     }
   }
 

--- a/test/it/uk/gov/hmrc/repository/StateHistoryRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/repository/StateHistoryRepositorySpec.scala
@@ -140,14 +140,13 @@ class StateHistoryRepositorySpec extends UnitSpec with MongoSpecSupport with Ind
 
   "The 'stateHistory' collection" should {
     "have all the indexes" in {
-      val indexVersion = Some(1)
       val expectedIndexes = Set(
-        Index(key = Seq("state" -> Ascending), name = Some("state"), unique = false, background = true, version = indexVersion),
-        Index(key = Seq("applicationId" -> Ascending), name = Some("applicationId"), unique = false, background = true, version = indexVersion),
-        Index(key = Seq("applicationId" -> Ascending, "state" -> Ascending), name = Some("applicationId_state"), unique = false, background = true, version = indexVersion),
-        Index(key = Seq("_id" -> Ascending), name = Some("_id_"), unique = false, background = false, version = indexVersion))
+        Index(key = Seq("state" -> Ascending), name = Some("state"), unique = false, background = true),
+        Index(key = Seq("applicationId" -> Ascending), name = Some("applicationId"), unique = false, background = true),
+        Index(key = Seq("applicationId" -> Ascending, "state" -> Ascending), name = Some("applicationId_state"), unique = false, background = true),
+        Index(key = Seq("_id" -> Ascending), name = Some("_id_"), unique = false, background = false))
 
-      verifyIndexes(repository, expectedIndexes)
+      verifyIndexesVersionAgnostic(repository, expectedIndexes)
     }
   }
 

--- a/test/it/uk/gov/hmrc/repository/SubscriptionRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/repository/SubscriptionRepositorySpec.scala
@@ -163,14 +163,13 @@ class SubscriptionRepositorySpec extends UnitSpec with MockitoSugar with MongoSp
 
   "The 'subscription' collection" should {
     "have all the indexes" in {
-      val indexVersion = Some(1)
       val expectedIndexes = Set(
-        Index(key = Seq("applications" -> Ascending), name = Some("applications"), unique = false, background = true, version = indexVersion),
-        Index(key = Seq("apiIdentifier.context" -> Ascending), name = Some("context"), unique = false, background = true, version = indexVersion),
-        Index(key = Seq("apiIdentifier.context" -> Ascending, "apiIdentifier.version" -> Ascending), name = Some("context_version"), unique = true, background = true, version = indexVersion),
-        Index(key = Seq("_id" -> Ascending), name = Some("_id_"), unique = false, background = false, version = indexVersion))
+        Index(key = Seq("applications" -> Ascending), name = Some("applications"), unique = false, background = true),
+        Index(key = Seq("apiIdentifier.context" -> Ascending), name = Some("context"), unique = false, background = true),
+        Index(key = Seq("apiIdentifier.context" -> Ascending, "apiIdentifier.version" -> Ascending), name = Some("context_version"), unique = true, background = true),
+        Index(key = Seq("_id" -> Ascending), name = Some("_id_"), unique = false, background = false))
 
-      verifyIndexes(repository, expectedIndexes)
+      verifyIndexesVersionAgnostic(repository, expectedIndexes)
     }
   }
 

--- a/test/it/uk/gov/hmrc/repository/package.scala
+++ b/test/it/uk/gov/hmrc/repository/package.scala
@@ -26,12 +26,14 @@ import scala.concurrent.duration._
 
 trait IndexVerification extends UnitSpec with Eventually {
 
-  def verifyIndexes[A, ID](repository: ReactiveRepository[A, ID], indexes: Set[Index])(implicit ec: ExecutionContext) = {
+  def verifyIndexesVersionAgnostic[A, ID](repository: ReactiveRepository[A, ID], indexes: Set[Index])(implicit ec: ExecutionContext) = {
     eventually(timeout(10.seconds), interval(1000.milliseconds)) {
       val actualIndexes = await(repository.collection.indexesManager.list()).toSet
       println(actualIndexes)
-      actualIndexes shouldBe indexes
+      versionAgnostic(actualIndexes) shouldBe versionAgnostic(indexes)
     }
   }
+
+  private def versionAgnostic(indexes: Set[Index]): Set[Index] = indexes.map(i => i.copy(version = None))
 }
 


### PR DESCRIPTION
… work with Mongo v3.2 and v3.4 - ignoring the index version, which has increased from 1 to 2 for these releases.