### PR TITLE
API-3679: Application Searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 logs
+classes
 project/project
 project/target
 target
@@ -22,5 +23,3 @@ node_modules/
 npm-debug.log
 yarn-debug.log
 yarn-error.log
-
-    

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -211,7 +211,7 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
   }
 
   def searchApplications = Action.async { implicit request =>
-    applicationService.searchApplications(new ApplicationSearch(request)).map(apps => Ok(toJson(apps))) recover recovery
+    applicationService.searchApplications(ApplicationSearch.fromRequest(request)).map(apps => Ok(toJson(apps))) recover recovery
   }
 
   private def fetchByServerToken(serverToken: String) = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -211,7 +211,7 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
   }
 
   def searchApplications = Action.async { implicit request =>
-    applicationService.searchApplications(new ApplicationSearch(request)).map(apps => Ok(toJson(apps)))
+    applicationService.searchApplications(new ApplicationSearch(request)).map(apps => Ok(toJson(apps))) recover recovery
   }
 
   private def fetchByServerToken(serverToken: String) = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.thirdpartyapplication.connector.AuthConnector
 import uk.gov.hmrc.thirdpartyapplication.controllers.ErrorCode._
 import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.thirdpartyapplication.models.AccessType.{PRIVILEGED, ROPC}
+import uk.gov.hmrc.thirdpartyapplication.models.{ApplicationSearch, ApplicationSearchFilter}
 import uk.gov.hmrc.thirdpartyapplication.models.AuthRole.APIGatekeeper
 import uk.gov.hmrc.thirdpartyapplication.models.JsonFormatters._
 import uk.gov.hmrc.thirdpartyapplication.models._
@@ -207,6 +208,10 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
         fetchAllWithNoSubscriptions()
       case _ => fetchAll()
     }
+  }
+
+  def searchApplications = Action.async { implicit request =>
+    applicationService.searchApplications(new ApplicationSearch(request)).map(apps => Ok(toJson(apps)))
   }
 
   private def fetchByServerToken(serverToken: String) = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.thirdpartyapplication.connector.AuthConnector
 import uk.gov.hmrc.thirdpartyapplication.controllers.ErrorCode._
 import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.thirdpartyapplication.models.AccessType.{PRIVILEGED, ROPC}
-import uk.gov.hmrc.thirdpartyapplication.models.{ApplicationSearch, ApplicationSearchFilter}
+import uk.gov.hmrc.thirdpartyapplication.models.ApplicationSearch
 import uk.gov.hmrc.thirdpartyapplication.models.AuthRole.APIGatekeeper
 import uk.gov.hmrc.thirdpartyapplication.models.JsonFormatters._
 import uk.gov.hmrc.thirdpartyapplication.models._

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -211,7 +211,7 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
   }
 
   def searchApplications = Action.async { implicit request =>
-    applicationService.searchApplications(ApplicationSearch.fromRequest(request)).map(apps => Ok(toJson(apps))) recover recovery
+    applicationService.searchApplications(ApplicationSearch.fromQueryString(request.queryString)).map(apps => Ok(toJson(apps))) recover recovery
   }
 
   private def fetchByServerToken(serverToken: String) = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.thirdpartyapplication.models
 
-import play.api.mvc.{AnyContent, Request}
-
 case class ApplicationSearch(pageNumber: Int = 1,
                              pageSize: Int = Int.MaxValue,
                              filters: Seq[ApplicationSearchFilter] = Seq(),
@@ -26,11 +24,11 @@ case class ApplicationSearch(pageNumber: Int = 1,
                              apiVersion: Option[String] = None)
 
 object ApplicationSearch {
-  def fromRequest(request: Request[AnyContent]): ApplicationSearch = {
-    def pageNumber = request.queryString.getOrElse("page", Seq()).headOption.getOrElse("1").toInt
-    def pageSize = request.queryString.getOrElse("pageSize", Seq()).headOption.getOrElse(Int.MaxValue.toString).toInt
+  def fromQueryString(queryString: Map[String, Seq[String]]): ApplicationSearch = {
+    def pageNumber = queryString.getOrElse("page", Seq()).headOption.getOrElse("1").toInt
+    def pageSize = queryString.getOrElse("pageSize", Seq()).headOption.getOrElse(Int.MaxValue.toString).toInt
 
-    def filters = request.queryString
+    def filters = queryString
       .map {
         case (key, value) =>
           // 'value' is a Seq, but we should only ever have one of each, so just take the head
@@ -47,9 +45,9 @@ object ApplicationSearch {
       .flatten
       .toSeq
 
-    def searchText = request.getQueryString("search")
-    def apiSubscription = request.getQueryString("apiSubscription")
-    def apiVersion = request.getQueryString("apiVersion")
+    def searchText = queryString.getOrElse("search", Seq()).headOption
+    def apiSubscription = queryString.getOrElse("apiSubscription", Seq()).headOption
+    def apiVersion = queryString.getOrElse("apiVersion", Seq()).headOption
 
     new ApplicationSearch(pageNumber, pageSize, filters, searchText, apiSubscription, apiVersion)
   }

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.thirdpartyapplication.models
+
+import play.api.mvc.{AnyContent, Request}
+
+class ApplicationSearch(request: Request[AnyContent]) {
+  var pageNumber: Int = request.getQueryString("page").getOrElse("1").toInt
+  var pageSize: Int = request.getQueryString("pageSize").getOrElse("100").toInt
+  var filters: Seq[ApplicationSearchFilter] =
+    request.queryString
+      .map(entry => parseQueryStringSearchFilter(entry._1, entry._2.head)) // Only expecting a single value for each query string
+      .filter(searchFilter => searchFilter.isDefined)
+      .flatten
+      .toSeq
+
+  def parseQueryStringSearchFilter(key: String, value: String): Option[ApplicationSearchFilter] = {
+    key match {
+      case "apiSubscriptions" => APISubscriptionFilter(value)
+      case "status" => ApplicationStatusFilter(value)
+      case "termsOfUse" => TermsOfUseStatusFilter(value)
+      case "accessType" => AccessTypeFilter(value)
+      case _ => None
+    }
+  }
+}
+
+sealed trait ApplicationSearchFilter
+
+sealed trait SearchTextFilter extends ApplicationSearchFilter {
+  var text: String
+}
+//case object SearchTextFilter extends SearchTextFilter {
+//  def apply(value: String): SearchTextFilter = {
+//    this.text = value
+//    this
+//  }
+//}
+
+sealed trait APISubscriptionFilter extends ApplicationSearchFilter
+case object OneOrMoreAPISubscriptions extends APISubscriptionFilter
+case object NoAPISubscriptions extends APISubscriptionFilter
+
+case object APISubscriptionFilter extends APISubscriptionFilter {
+  def apply(value: String): Option[APISubscriptionFilter] = {
+    value match {
+      case "ANYSUB" => Some(OneOrMoreAPISubscriptions)
+      case "NOSUB" => Some(NoAPISubscriptions)
+      case _ => None
+    }
+  }
+}
+
+sealed trait StatusFilter extends ApplicationSearchFilter
+case object Created extends StatusFilter
+case object PendingGatekeeperCheck extends StatusFilter
+case object PendingSubmitterVerification extends StatusFilter
+case object Active extends StatusFilter
+
+case object ApplicationStatusFilter extends StatusFilter {
+  def apply(value: String): Option[StatusFilter] = {
+    value match {
+      case "CREATED" => Some(Created)
+      case "PENDING_GATEKEEPER_CHECK" => Some(PendingGatekeeperCheck)
+      case "PENDING_SUBMITTER_VERIFICATION" => Some(PendingSubmitterVerification)
+      case "ACTIVE" => Some(Active)
+      case _ => None
+    }
+  }
+}
+sealed trait TermsOfUseFilter extends ApplicationSearchFilter
+case object TermsOfUseNotAccepted extends TermsOfUseFilter
+case object TermsOfUseAccepted extends TermsOfUseFilter
+
+case object TermsOfUseStatusFilter extends TermsOfUseFilter {
+  def apply(value: String): Option[TermsOfUseFilter] = {
+    value match {
+      case "TOU_NOT_ACCEPTED" => Some(TermsOfUseNotAccepted)
+      case "TOU_ACCEPTED" => Some(TermsOfUseAccepted)
+      case _ => None
+    }
+  }
+}
+
+sealed trait AccessTypeFilter extends ApplicationSearchFilter
+case object StandardAccess extends AccessTypeFilter
+case object ROPCAccess extends AccessTypeFilter
+case object PrivilegedAccess extends AccessTypeFilter
+
+case object AccessTypeFilter extends AccessTypeFilter {
+  def apply(value: String): Option[AccessTypeFilter] = {
+    value match {
+      case "ACCESS_TYPE_STANDARD" => Some(StandardAccess)
+      case "ACCESS_TYPE_ROPC" => Some(ROPCAccess)
+      case "ACCESS_TYPE_PRIVILEGED" => Some(PrivilegedAccess)
+      case _ => None
+    }
+  }
+}

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -18,17 +18,17 @@ package uk.gov.hmrc.thirdpartyapplication.models
 
 import play.api.mvc.{AnyContent, Request}
 
-case class ApplicationSearch(var pageNumber: Int = 1,
-                        var pageSize: Int = Int.MaxValue,
-                        var filters: Seq[ApplicationSearchFilter] = Seq(),
-                        var textToSearch: String = "",
-                        var apiContext: String = "",
-                        var apiVersion: String = "")
+case class ApplicationSearch(pageNumber: Int = 1,
+                             pageSize: Int = Int.MaxValue,
+                             filters: Seq[ApplicationSearchFilter] = Seq(),
+                             textToSearch: Option[String] = None,
+                             apiContext: Option[String] = None,
+                             apiVersion: Option[String] = None)
 
 object ApplicationSearch {
   def fromRequest(request: Request[AnyContent]): ApplicationSearch = {
-    def pageNumber = request.queryString.getOrElse("page", Seq("1")).head.toInt
-    def pageSize = request.queryString.getOrElse("pageSize", Seq(Int.MaxValue.toString)).head.toInt
+    def pageNumber = request.queryString.getOrElse("page", Seq()).headOption.getOrElse("1").toInt
+    def pageSize = request.queryString.getOrElse("pageSize", Seq()).headOption.getOrElse(Int.MaxValue.toString).toInt
 
     def filters = request.queryString
       .map {
@@ -47,9 +47,9 @@ object ApplicationSearch {
       .flatten
       .toSeq
 
-    def searchText = if(filters.contains(ApplicationTextSearch)) request.getQueryString("search").getOrElse("") else ""
-    def apiSubscription = if(filters.contains(SpecificAPISubscription)) request.getQueryString("apiSubscription").getOrElse("") else ""
-    def apiVersion = if(filters.contains(SpecificAPISubscription)) request.getQueryString("apiVersion").getOrElse("") else ""
+    def searchText = request.getQueryString("search")
+    def apiSubscription = request.getQueryString("apiSubscription")
+    def apiVersion = request.getQueryString("apiVersion")
 
     new ApplicationSearch(pageNumber, pageSize, filters, searchText, apiSubscription, apiVersion)
   }

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -18,41 +18,23 @@ package uk.gov.hmrc.thirdpartyapplication.models
 
 import play.api.mvc.{AnyContent, Request}
 
-class ApplicationSearch(var pageNumber: Int,
-                        var pageSize: Int,
-                        var filters: Seq[ApplicationSearchFilter],
+case class ApplicationSearch(var pageNumber: Int = 1,
+                        var pageSize: Int = Int.MaxValue,
+                        var filters: Seq[ApplicationSearchFilter] = Seq(),
                         var textToSearch: String = "",
                         var apiContext: String = "",
-                        var apiVersion: String = "") {
-
-  def this(filters: Seq[ApplicationSearchFilter], apiContext: String, apiVersion: String) {
-    this(ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, filters, "", apiContext, apiVersion)
-  }
-
-  def this(filters: Seq[ApplicationSearchFilter], textToSearch: String) {
-    this(ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, filters, textToSearch)
-  }
-
-  def this(filters: Seq[ApplicationSearchFilter]) {
-    this(filters, "")
-  }
-
-  def this() {
-    this(Seq.empty)
-  }
-}
+                        var apiVersion: String = "")
 
 object ApplicationSearch {
-  val PageNumberParameterName = "page"
-  val PageSizeParameterName = "pageSize"
+  private val PageNumberParameterName = "page"
+  private val PageSizeParameterName = "pageSize"
 
   // Set paging defaults that mean we'll get everything back (so that a search specifying only filters will get all relevant results)
-  val DefaultPageNumber: Int = 1
-  val DefaultPageSize: Int = Int.MaxValue
+  private val DefaultPageNumber = "1"
+  private val DefaultPageSize: Int = Int.MaxValue
 
   def fromRequest(request: Request[AnyContent]): ApplicationSearch = {
-    def pageNumber =
-      if (request.getQueryString(PageNumberParameterName).isDefined) request.getQueryString(PageNumberParameterName).get.toInt else DefaultPageNumber
+    def pageNumber = request.getQueryString(PageNumberParameterName).getOrElse("1").toInt
     def pageSize =
       if (request.getQueryString(PageSizeParameterName).isDefined) request.getQueryString(PageSizeParameterName).get.toInt else DefaultPageSize
 

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -26,17 +26,9 @@ case class ApplicationSearch(var pageNumber: Int = 1,
                         var apiVersion: String = "")
 
 object ApplicationSearch {
-  private val PageNumberParameterName = "page"
-  private val PageSizeParameterName = "pageSize"
-
-  // Set paging defaults that mean we'll get everything back (so that a search specifying only filters will get all relevant results)
-  private val DefaultPageNumber = "1"
-  private val DefaultPageSize: Int = Int.MaxValue
-
   def fromRequest(request: Request[AnyContent]): ApplicationSearch = {
-    def pageNumber = request.getQueryString(PageNumberParameterName).getOrElse("1").toInt
-    def pageSize =
-      if (request.getQueryString(PageSizeParameterName).isDefined) request.getQueryString(PageSizeParameterName).get.toInt else DefaultPageSize
+    def pageNumber = request.queryString.getOrElse("page", Seq("1")).head.toInt
+    def pageSize = request.queryString.getOrElse("pageSize", Seq(Int.MaxValue.toString)).head.toInt
 
     def filters = request.queryString
       .map {

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -104,8 +104,8 @@ case object APISubscriptionFilter extends APISubscriptionFilter {
   def apply(value: String): Option[APISubscriptionFilter] = {
 
     value match {
-      case "ANYSUB" => Some(OneOrMoreAPISubscriptions)
-      case "NOSUB" => Some(NoAPISubscriptions)
+      case "ANY" => Some(OneOrMoreAPISubscriptions)
+      case "NONE" => Some(NoAPISubscriptions)
       case _ if !value.isEmpty => Some(SpecificAPISubscription) // If the value of apiSubscription is something else, assume we are searching for a specific API
       case _ => None
     }
@@ -136,8 +136,8 @@ case object TermsOfUseAccepted extends TermsOfUseFilter
 case object TermsOfUseStatusFilter extends TermsOfUseFilter {
   def apply(value: String): Option[TermsOfUseFilter] = {
     value match {
-      case "TOU_NOT_ACCEPTED" => Some(TermsOfUseNotAccepted)
-      case "TOU_ACCEPTED" => Some(TermsOfUseAccepted)
+      case "NOT_ACCEPTED" => Some(TermsOfUseNotAccepted)
+      case "ACCEPTED" => Some(TermsOfUseAccepted)
       case _ => None
     }
   }
@@ -151,9 +151,9 @@ case object PrivilegedAccess extends AccessTypeFilter
 case object AccessTypeFilter extends AccessTypeFilter {
   def apply(value: String): Option[AccessTypeFilter] = {
     value match {
-      case "ACCESS_TYPE_STANDARD" => Some(StandardAccess)
-      case "ACCESS_TYPE_ROPC" => Some(ROPCAccess)
-      case "ACCESS_TYPE_PRIVILEGED" => Some(PrivilegedAccess)
+      case "STANDARD" => Some(StandardAccess)
+      case "ROPC" => Some(ROPCAccess)
+      case "PRIVILEGED" => Some(PrivilegedAccess)
       case _ => None
     }
   }

--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -18,10 +18,14 @@ package uk.gov.hmrc.thirdpartyapplication.models
 
 import play.api.mvc.{AnyContent, Request}
 
-class ApplicationSearch(var pageNumber: Int, var pageSize: Int, var filters: Seq[ApplicationSearchFilter]) {
+class ApplicationSearch(var pageNumber: Int, var pageSize: Int, var filters: Seq[ApplicationSearchFilter], var textToSearch: String = "") {
+
+  def this(filters: Seq[ApplicationSearchFilter], textToSearch: String) {
+    this(ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, filters, textToSearch)
+  }
 
   def this(filters: Seq[ApplicationSearchFilter]) {
-    this(ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, filters)
+    this(filters, "")
   }
 
   def this() {
@@ -50,7 +54,8 @@ class ApplicationSearch(var pageNumber: Int, var pageSize: Int, var filters: Seq
         }
         .filter(searchFilter => searchFilter.isDefined)
         .flatten
-        .toSeq)
+        .toSeq,
+      request.getQueryString("search").getOrElse(""))
   }
 }
 
@@ -64,16 +69,6 @@ object ApplicationSearch {
 }
 
 sealed trait ApplicationSearchFilter
-
-sealed trait SearchTextFilter extends ApplicationSearchFilter {
-  var text: String
-}
-//case object SearchTextFilter extends SearchTextFilter {
-//  def apply(value: String): SearchTextFilter = {
-//    this.text = value
-//    this
-//  }
-//}
 
 sealed trait APISubscriptionFilter extends ApplicationSearchFilter
 case object OneOrMoreAPISubscriptions extends APISubscriptionFilter

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -170,7 +170,7 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
 
     def buildFindQuery(filters : Seq[ApplicationSearchFilter]): JsObject = {
       if(filters.isEmpty) {
-        Json.obj()
+        Json.obj() // Must return an empty JSON object for the find() clause of the MongoDB query if we have no filters
       } else {
         Json.obj("$and" -> applicationSearch.filters.map(filter => convertFilterToQueryClause(filter)))
       }

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -258,12 +258,12 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
   }
 
   def fetchAllForContext(apiContext: String): Future[Seq[ApplicationData]] =
-    searchApplications(new ApplicationSearch(Seq(SpecificAPISubscription), apiContext = apiContext, apiVersion = ""))
+    searchApplications(ApplicationSearch(1, Int.MaxValue, Seq(SpecificAPISubscription), apiContext = apiContext))
 
   def fetchAllForApiIdentifier(apiIdentifier: APIIdentifier): Future[Seq[ApplicationData]] =
-    searchApplications(new ApplicationSearch(Seq(SpecificAPISubscription), apiContext = apiIdentifier.context, apiVersion = apiIdentifier.version))
+    searchApplications(ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = apiIdentifier.context, apiVersion = apiIdentifier.version))
 
-  def fetchAllWithNoSubscriptions(): Future[Seq[ApplicationData]] = searchApplications(new ApplicationSearch(Seq(NoAPISubscriptions)))
+  def fetchAllWithNoSubscriptions(): Future[Seq[ApplicationData]] = searchApplications(new ApplicationSearch(filters = Seq(NoAPISubscriptions)))
 
   def fetchAll(): Future[Seq[ApplicationData]] = searchApplications(new ApplicationSearch())
 

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -179,7 +179,7 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
           // API Subscriptions
           case NoAPISubscriptions => Match(BSONDocument("subscribedApis" -> BSONDocument("$size" -> 0)))
           case OneOrMoreAPISubscriptions => Match(BSONDocument("subscribedApis" -> BSONDocument("$gt" -> BSONDocument("$size" -> 0))))
-            
+
           // Application Status
           case Created => Match(BSONDocument("state.name" -> State.TESTING.toString))
           case PendingGatekeeperCheck => Match(BSONDocument("state.name" -> State.PENDING_GATEKEEPER_APPROVAL.toString))
@@ -246,14 +246,9 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
       Match(BSONDocument("subscribedApis.apiIdentifier" -> BSONDocument("context" -> apiIdentifier.context, "version" -> apiIdentifier.version))),
       applicationProjection)
 
-  def fetchAllWithNoSubscriptions(): Future[Seq[ApplicationData]] =
-    lookupByAPI(
-      Match(BSONDocument("subscribedApis" -> BSONDocument("$size" -> 0))),
-      applicationProjection)
+  def fetchAllWithNoSubscriptions(): Future[Seq[ApplicationData]] = searchApplications(new ApplicationSearch(Seq(NoAPISubscriptions)))
 
-  def fetchAll(): Future[Seq[ApplicationData]] = {
-    collection.find(Json.obj()).cursor[ApplicationData]().collect[Seq]()
-  }
+  def fetchAll(): Future[Seq[ApplicationData]] = searchApplications(new ApplicationSearch())
 
   def delete(id: UUID): Future[HasSucceeded] = {
     collection.remove(Json.obj("id" -> id)).map(_ => HasSucceeded)

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -165,6 +165,10 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
     find("collaborators.emailAddress" -> emailAddress, "environment" -> environment)
   }
 
+  def searchApplications(applicationSearch: ApplicationSearch): Future[Seq[ApplicationData]] = {
+    Future.successful(Seq())
+  }
+
   private def processResults[T](json: JsObject)(implicit fjs: Reads[T]): Future[T] = {
     (json \ "result").validate[T] match {
       case JsSuccess(result, _) => Future.successful(result)

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -177,7 +177,9 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
     def convertFilterToQueryClause(applicationSearchFilter: ApplicationSearchFilter): PipelineOperator = {
         applicationSearchFilter match {
           // API Subscriptions
-
+          case NoAPISubscriptions => Match(BSONDocument("subscribedApis" -> BSONDocument("$size" -> 0)))
+          case OneOrMoreAPISubscriptions => Match(BSONDocument("subscribedApis" -> BSONDocument("$gt" -> BSONDocument("$size" -> 0))))
+            
           // Application Status
           case Created => Match(BSONDocument("state.name" -> State.TESTING.toString))
           case PendingGatekeeperCheck => Match(BSONDocument("state.name" -> State.PENDING_GATEKEEPER_APPROVAL.toString))

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -187,6 +187,15 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
           case Active => Match(BSONDocument("state.name" -> State.PRODUCTION.toString()))
 
           // Terms of Use
+          case TermsOfUseAccepted => Match(BSONDocument("checkInformation.termsOfUseAgreements" -> BSONDocument("$gt" -> BSONDocument("$size" -> 0))))
+          case TermsOfUseNotAccepted =>
+            Match(
+              BSONDocument(
+                "$or" ->
+                  BSONArray(
+                    BSONDocument("checkInformation" -> BSONDocument("$exists" -> false)),
+                    BSONDocument("checkInformation.termsOfUseAgreements" -> BSONDocument("$exists" -> false),
+                    BSONDocument("checkInformation.termsOfUseAgreements" -> BSONDocument("$size" -> 0))))))
 
           // Access Type
           case StandardAccess => Match(BSONDocument("access.accessType" -> AccessType.STANDARD.toString))

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json._
 import play.api.libs.json._
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.commands.Command
-import reactivemongo.api.{Cursor, FailoverStrategy, ReadPreference}
+import reactivemongo.api.{FailoverStrategy, ReadPreference}
 import reactivemongo.bson.{BSONArray, BSONBoolean, BSONDocument, BSONObjectID, BSONRegex}
 import reactivemongo.core.commands._
 import reactivemongo.play.json.ImplicitBSONHandlers._

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
@@ -266,7 +266,9 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
   }
 
   def searchApplications(applicationSearch: ApplicationSearch): Future[Seq[ApplicationResponse]] = {
-    Future(Seq())
+    applicationRepository.searchApplications(applicationSearch).map {
+      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+    }
   }
 
   def requestUplift(applicationId: UUID, applicationName: String,

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
@@ -265,6 +265,10 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
     }
   }
 
+  def searchApplications(applicationSearch: ApplicationSearch): Future[Seq[ApplicationResponse]] = {
+    Future(Seq())
+  }
+
   def requestUplift(applicationId: UUID, applicationName: String,
                     requestedByEmailAddress: String)(implicit hc: HeaderCarrier): Future[ApplicationStateChange] = {
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,6 +2,8 @@
 
 GET           /developer/applications                                uk.gov.hmrc.thirdpartyapplication.controllers.ApplicationController.queryDispatcher()
 
+GET           /applications                                          uk.gov.hmrc.thirdpartyapplication.controllers.ApplicationController.searchApplications
+
 GET           /application                                           uk.gov.hmrc.thirdpartyapplication.controllers.ApplicationController.queryDispatcher()
 GET           /application/wso2-credentials                          uk.gov.hmrc.thirdpartyapplication.controllers.ApplicationController.fetchWso2Credentials(clientId: String)
 GET           /application/subscriptions                             uk.gov.hmrc.thirdpartyapplication.controllers.ApplicationController.fetchAllAPISubscriptions()

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -272,28 +272,40 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       )
       applications.foreach(application => await(applicationRepository.save(application)))
 
-      verifyApplications(await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)), State.PENDING_REQUESTER_VERIFICATION, 1)
+      verifyApplications(
+        await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)),
+        State.PENDING_REQUESTER_VERIFICATION,
+        1)
     }
 
     "retrieve the application with PENDING_REQUESTER_VERIFICATION state that have been updated before the dayOfExpiry" in {
       val application = createAppWithStatusUpdatedOn(State.PENDING_REQUESTER_VERIFICATION, expiryOnTheDayBefore)
       await(applicationRepository.save(application))
 
-      verifyApplications(await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)), State.PENDING_REQUESTER_VERIFICATION, 1)
+      verifyApplications(
+        await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)),
+        State.PENDING_REQUESTER_VERIFICATION,
+        1)
     }
 
     "retrieve the application with PENDING_REQUESTER_VERIFICATION state that have been updated on the dayOfExpiry" in {
       val application = createAppWithStatusUpdatedOn(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)
       await(applicationRepository.save(application))
 
-      verifyApplications(await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)), State.PENDING_REQUESTER_VERIFICATION, 1)
+      verifyApplications(
+        await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)),
+        State.PENDING_REQUESTER_VERIFICATION,
+        1)
     }
 
     "retrieve no application with PENDING_REQUESTER_VERIFICATION state that have been updated after the dayOfExpiry" in {
       val application = createAppWithStatusUpdatedOn(State.PENDING_REQUESTER_VERIFICATION, expiryOnTheDayAfter)
       await(applicationRepository.save(application))
 
-      verifyApplications(await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)), State.PENDING_REQUESTER_VERIFICATION, 0)
+      verifyApplications(
+        await(applicationRepository.fetchAllByStatusDetails(State.PENDING_REQUESTER_VERIFICATION, dayOfExpiry)),
+        State.PENDING_REQUESTER_VERIFICATION,
+        0)
     }
 
   }
@@ -700,7 +712,8 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(subscriptionRepository.insert(aSubscriptionData(apiContext, expectedAPIVersion, expectedApplication.id)))
       await(subscriptionRepository.insert(aSubscriptionData(apiContext, otherAPIVersion, otherApplication.id)))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = Some(apiContext), apiVersion = Some(expectedAPIVersion))
+      val applicationSearch =
+        new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = Some(apiContext), apiVersion = Some(expectedAPIVersion))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -465,9 +465,6 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application1))
       await(applicationRepository.save(application2))
       await(applicationRepository.save(application3))
-      await(subscriptionRepository.insert(aSubscriptionData("context", "version-1", application1.id)))
-      await(subscriptionRepository.insert(aSubscriptionData("context", "version-2", application2.id)))
-      await(subscriptionRepository.insert(aSubscriptionData("other", "version-2", application2.id, application3.id)))
 
       val applicationSearch = new ApplicationSearch(pageNumber = 2, pageSize = 1, filters = Seq.empty)
 

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -541,7 +541,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = applicationId.toString)
+      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = Some(applicationId.toString))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -558,7 +558,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = applicationName)
+      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = Some(applicationName))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -577,7 +577,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(standardApplication))
       await(applicationRepository.save(ropcApplication))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(ROPCAccess), textToSearch = applicationName)
+      val applicationSearch = new ApplicationSearch(filters = Seq(ROPCAccess), textToSearch = Some(applicationName))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -594,7 +594,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = "application")
+      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = Some("application"))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -680,7 +680,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(subscriptionRepository.insert(aSubscriptionData(expectedAPIContext, "version-1", expectedApplication.id)))
       await(subscriptionRepository.insert(aSubscriptionData(otherAPIContext, "version-1", otherApplication.id)))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = expectedAPIContext, apiVersion = "")
+      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = Some(expectedAPIContext), apiVersion = Some(""))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -700,7 +700,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(subscriptionRepository.insert(aSubscriptionData(apiContext, expectedAPIVersion, expectedApplication.id)))
       await(subscriptionRepository.insert(aSubscriptionData(apiContext, otherAPIVersion, otherApplication.id)))
 
-      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = apiContext, apiVersion = expectedAPIVersion)
+      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = Some(apiContext), apiVersion = Some(expectedAPIVersion))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -480,7 +480,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationInTest))
       await(applicationRepository.save(applicationInProduction))
 
-      val applicationSearch = new ApplicationSearch(pageNumber = 1, pageSize = 100, filters = Seq(Active))
+      val applicationSearch = new ApplicationSearch(Seq(Active))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -494,7 +494,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(standardApplication))
       await(applicationRepository.save(ropcApplication))
 
-      val applicationSearch = new ApplicationSearch(pageNumber = 1, pageSize = 100, filters = Seq(ROPCAccess))
+      val applicationSearch = new ApplicationSearch(Seq(ROPCAccess))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -509,7 +509,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithoutSubscriptions))
       await(subscriptionRepository.insert(aSubscriptionData("context", "version-1", applicationWithSubscriptions.id)))
 
-      val applicationSearch = new ApplicationSearch(pageNumber = 1, pageSize = 100, filters = Seq(NoAPISubscriptions))
+      val applicationSearch = new ApplicationSearch(Seq(NoAPISubscriptions))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -524,7 +524,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithoutSubscriptions))
       await(subscriptionRepository.insert(aSubscriptionData("context", "version-1", applicationWithSubscriptions.id)))
 
-      val applicationSearch = new ApplicationSearch(pageNumber = 1, pageSize = 100, filters = Seq(OneOrMoreAPISubscriptions))
+      val applicationSearch = new ApplicationSearch(Seq(OneOrMoreAPISubscriptions))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -585,6 +585,22 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       result.size shouldBe 1
       result.head.id shouldBe ropcApplication.id
     }
+
+    "return applications matching search text in a case-insensitive manner" in {
+      val applicationId = UUID.randomUUID()
+
+      val application = aNamedApplicationData(applicationId, "TEST APPLICATION", prodClientId = generateClientId, sandboxClientId = generateClientId)
+      val randomOtherApplication = anApplicationData(UUID.randomUUID(), prodClientId = generateClientId, sandboxClientId = generateClientId)
+      await(applicationRepository.save(application))
+      await(applicationRepository.save(randomOtherApplication))
+
+      val applicationSearch = new ApplicationSearch(Seq(), "application")
+
+      val result = await(applicationRepository.searchApplications(applicationSearch))
+
+      result.size shouldBe 1
+      result.head.id shouldBe applicationId
+    }
   }
 
   def createAppWithStatusUpdatedOn(state: State.State, updatedOn: DateTime) = anApplicationData(

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -541,7 +541,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq.empty, applicationId.toString)
+      val applicationSearch = new ApplicationSearch(Seq(ApplicationTextSearch), applicationId.toString)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -558,7 +558,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq.empty, applicationName)
+      val applicationSearch = new ApplicationSearch(Seq(ApplicationTextSearch), applicationName)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -594,7 +594,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq.empty, "application")
+      val applicationSearch = new ApplicationSearch(Seq(ApplicationTextSearch), "application")
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -480,7 +480,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationInTest))
       await(applicationRepository.save(applicationInProduction))
 
-      val applicationSearch = new ApplicationSearch(Seq(Active))
+      val applicationSearch = new ApplicationSearch(filters = Seq(Active))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -494,7 +494,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(standardApplication))
       await(applicationRepository.save(ropcApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(ROPCAccess))
+      val applicationSearch = new ApplicationSearch(filters = Seq(ROPCAccess))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -509,7 +509,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithoutSubscriptions))
       await(subscriptionRepository.insert(aSubscriptionData("context", "version-1", applicationWithSubscriptions.id)))
 
-      val applicationSearch = new ApplicationSearch(Seq(NoAPISubscriptions))
+      val applicationSearch = new ApplicationSearch(filters = Seq(NoAPISubscriptions))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -524,7 +524,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithoutSubscriptions))
       await(subscriptionRepository.insert(aSubscriptionData("context", "version-1", applicationWithSubscriptions.id)))
 
-      val applicationSearch = new ApplicationSearch(Seq(OneOrMoreAPISubscriptions))
+      val applicationSearch = ApplicationSearch(filters = Seq(OneOrMoreAPISubscriptions))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -541,7 +541,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(ApplicationTextSearch), applicationId.toString)
+      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = applicationId.toString)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -558,7 +558,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(ApplicationTextSearch), applicationName)
+      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = applicationName)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -577,7 +577,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(standardApplication))
       await(applicationRepository.save(ropcApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(ROPCAccess), applicationName)
+      val applicationSearch = new ApplicationSearch(filters = Seq(ROPCAccess), textToSearch = applicationName)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -594,7 +594,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(ApplicationTextSearch), "application")
+      val applicationSearch = new ApplicationSearch(filters = Seq(ApplicationTextSearch), textToSearch = "application")
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -615,7 +615,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithTermsOfUseAgreed))
       await(applicationRepository.save(applicationWithNoTermsOfUseAgreed))
 
-      val applicationSearch = new ApplicationSearch(Seq(TermsOfUseAccepted))
+      val applicationSearch = new ApplicationSearch(filters = Seq(TermsOfUseAccepted))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -636,7 +636,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithNoCheckInformation))
       await(applicationRepository.save(applicationWithTermsOfUseAgreed))
 
-      val applicationSearch = new ApplicationSearch(Seq(TermsOfUseNotAccepted))
+      val applicationSearch = new ApplicationSearch(filters = Seq(TermsOfUseNotAccepted))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -661,7 +661,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(applicationWithNoTermsOfUseAgreed))
       await(applicationRepository.save(applicationWithTermsOfUseAgreed))
 
-      val applicationSearch = new ApplicationSearch(Seq(TermsOfUseNotAccepted))
+      val applicationSearch = new ApplicationSearch(filters = Seq(TermsOfUseNotAccepted))
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -680,7 +680,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(subscriptionRepository.insert(aSubscriptionData(expectedAPIContext, "version-1", expectedApplication.id)))
       await(subscriptionRepository.insert(aSubscriptionData(otherAPIContext, "version-1", otherApplication.id)))
 
-      val applicationSearch = new ApplicationSearch(Seq(SpecificAPISubscription), apiContext = expectedAPIContext, apiVersion = "")
+      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = expectedAPIContext, apiVersion = "")
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -700,7 +700,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(subscriptionRepository.insert(aSubscriptionData(apiContext, expectedAPIVersion, expectedApplication.id)))
       await(subscriptionRepository.insert(aSubscriptionData(apiContext, otherAPIVersion, otherApplication.id)))
 
-      val applicationSearch = new ApplicationSearch(Seq(SpecificAPISubscription), apiContext = apiContext, apiVersion = expectedAPIVersion)
+      val applicationSearch = new ApplicationSearch(filters = Seq(SpecificAPISubscription), apiContext = apiContext, apiVersion = expectedAPIVersion)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -541,7 +541,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(), applicationId.toString)
+      val applicationSearch = new ApplicationSearch(Seq.empty, applicationId.toString)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -558,7 +558,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(), applicationName)
+      val applicationSearch = new ApplicationSearch(Seq.empty, applicationName)
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -594,7 +594,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       await(applicationRepository.save(application))
       await(applicationRepository.save(randomOtherApplication))
 
-      val applicationSearch = new ApplicationSearch(Seq(), "application")
+      val applicationSearch = new ApplicationSearch(Seq.empty, "application")
 
       val result = await(applicationRepository.searchApplications(applicationSearch))
 
@@ -650,7 +650,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       val termsOfUseAgreement = new TermsOfUseAgreement("a@b.com", HmrcTime.now, "v1")
       val checkInformation = new CheckInformation(termsOfUseAgreements = Seq(termsOfUseAgreement))
 
-      val emptyCheckInformation = new CheckInformation(termsOfUseAgreements = Seq())
+      val emptyCheckInformation = new CheckInformation(termsOfUseAgreements = Seq.empty
 
       val applicationWithNoTermsOfUseAgreed =
         aNamedApplicationData(

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -650,7 +650,7 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
       val termsOfUseAgreement = new TermsOfUseAgreement("a@b.com", HmrcTime.now, "v1")
       val checkInformation = new CheckInformation(termsOfUseAgreements = Seq(termsOfUseAgreement))
 
-      val emptyCheckInformation = new CheckInformation(termsOfUseAgreements = Seq.empty
+      val emptyCheckInformation = new CheckInformation(termsOfUseAgreements = Seq.empty)
 
       val applicationWithNoTermsOfUseAgreed =
         aNamedApplicationData(

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationControllerSpec.scala
@@ -1372,6 +1372,20 @@ class ApplicationControllerSpec extends UnitSpec with ScalaFutures with MockitoS
     }
   }
 
+  "Search" should {
+    "pass an ApplicationSearch object to applicationService" in new Setup {
+      val req =
+        FakeRequest("GET", "/applications?apiSubscriptions=ANYSUB&page=1&pageSize=100")
+          .withHeaders("X-name" -> "blob", "X-email-address" -> "test@example.com", "X-Server-Token" -> "abc123")
+
+      when(underTest.applicationService.searchApplications(any[ApplicationSearch])).thenReturn(Future(Seq()))
+
+      val result = await(underTest.searchApplications(req))
+
+      status(result) shouldBe SC_OK
+    }
+  }
+
   private def anAPI() = {
     new APIIdentifier("some-context", "1.0")
   }

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -27,13 +27,13 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
   "ApplicationSearch" should {
     "set appropriate defaults for no-arg constructor" in {
-      checkCreatedSearchObject(new ApplicationSearch(), ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set.empty)
+      checkCreatedSearchObject(new ApplicationSearch(), expectedFilters =  Set.empty)
     }
 
     "set appropriate defaults for paging values" in {
-      val searchObject = new ApplicationSearch(Seq(OneOrMoreAPISubscriptions, ROPCAccess))
+      val searchObject = new ApplicationSearch(filters = Seq(OneOrMoreAPISubscriptions, ROPCAccess))
 
-      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(OneOrMoreAPISubscriptions, ROPCAccess))
+      checkCreatedSearchObject(searchObject, expectedFilters = Set(OneOrMoreAPISubscriptions, ROPCAccess))
     }
 
     "correctly parse page number and size" in {
@@ -62,7 +62,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(OneOrMoreAPISubscriptions))
+      checkCreatedSearchObject(searchObject, expectedFilters = Set(OneOrMoreAPISubscriptions))
     }
 
     "correctly parse Application Status filter" in {
@@ -70,7 +70,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(PendingGatekeeperCheck))
+      checkCreatedSearchObject(searchObject, expectedFilters = Set(PendingGatekeeperCheck))
     }
 
     "correctly parse Terms of Use filter" in {
@@ -78,7 +78,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(TermsOfUseNotAccepted))
+      checkCreatedSearchObject(searchObject, expectedFilters = Set(TermsOfUseNotAccepted))
     }
 
     "correctly parse Access Type filter" in {
@@ -86,7 +86,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(PrivilegedAccess))
+      checkCreatedSearchObject(searchObject, expectedFilters = Set(PrivilegedAccess))
     }
 
     "correctly parses multiple filters" in {
@@ -126,7 +126,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set.empty)
+      checkCreatedSearchObject(searchObject, expectedFilters = Set.empty)
     }
 
     "populate apiContext if specific value is provided" in {
@@ -136,7 +136,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(
-        searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(SpecificAPISubscription), expectedAPIContext = api)
+        searchObject, expectedFilters = Set(SpecificAPISubscription), expectedAPIContext = api)
     }
 
     "populate apiContext and apiVersion if specific values are provided" in {
@@ -148,18 +148,16 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       checkCreatedSearchObject(
         searchObject,
-        ApplicationSearch.DefaultPageNumber,
-        ApplicationSearch.DefaultPageSize,
-        Set(SpecificAPISubscription),
+        expectedFilters = Set(SpecificAPISubscription),
         expectedAPIContext = api,
         expectedAPIVersion = apiVersion)
     }
   }
 
   def checkCreatedSearchObject(searchObject: ApplicationSearch,
-                               expectedPageNumber: Int,
-                               expectedPageSize: Int,
-                               expectedFilters: Set[ApplicationSearchFilter],
+                               expectedPageNumber: Int = 1,
+                               expectedPageSize: Int = Int.MaxValue,
+                               expectedFilters: Set[ApplicationSearchFilter] = Set.empty,
                                expectedSearchText: String = "",
                                expectedAPIContext: String = "",
                                expectedAPIVersion: String = ""): Unit = {

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -58,7 +58,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     }
 
     "correctly parse API Subscriptions filter" in {
-      val request = FakeRequest("GET", s"/applications?apiSubscription=ANYSUB")
+      val request = FakeRequest("GET", s"/applications?apiSubscription=ANY")
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
@@ -74,7 +74,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     }
 
     "correctly parse Terms of Use filter" in {
-      val request = FakeRequest("GET", s"/applications?termsOfUse=TOU_NOT_ACCEPTED")
+      val request = FakeRequest("GET", s"/applications?termsOfUse=NOT_ACCEPTED")
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
@@ -82,7 +82,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     }
 
     "correctly parse Access Type filter" in {
-      val request = FakeRequest("GET", s"/applications?accessType=ACCESS_TYPE_PRIVILEGED")
+      val request = FakeRequest("GET", s"/applications?accessType=PRIVILEGED")
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
@@ -103,8 +103,8 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
             s"?apiSubscription=$expectedAPIContext" +
             s"&apiVersion=$expectedAPIVersion" +
             s"&status=CREATED" +
-            s"&termsOfUse=TOU_ACCEPTED" +
-            s"&accessType=ACCESS_TYPE_ROPC" +
+            s"&termsOfUse=ACCEPTED" +
+            s"&accessType=ROPC" +
             s"&search=$expectedSearchText" +
             s"&page=$expectedPageNumber" +
             s"&pageSize=$expectedPageSize")

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -26,15 +26,6 @@ import uk.gov.hmrc.thirdpartyapplication.models._
 class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with MockitoSugar with Matchers {
 
   "ApplicationSearch" should {
-    "set appropriate defaults for no-arg constructor" in {
-      checkCreatedSearchObject(new ApplicationSearch(), expectedFilters =  Set.empty)
-    }
-
-    "set appropriate defaults for paging values" in {
-      val searchObject = new ApplicationSearch(filters = Seq(OneOrMoreAPISubscriptions, ROPCAccess))
-
-      checkCreatedSearchObject(searchObject, expectedFilters = Set(OneOrMoreAPISubscriptions, ROPCAccess))
-    }
 
     "correctly parse page number and size" in {
       val expectedPageNumber: Int = 2
@@ -43,7 +34,8 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, expectedPageNumber, expectedPageSize, Set.empty)
+      searchObject.pageNumber shouldBe expectedPageNumber
+      searchObject.pageSize shouldBe expectedPageSize
     }
 
     "correctly parse search text filter" in {
@@ -53,8 +45,8 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val searchObject = ApplicationSearch.fromRequest(request)
 
       searchObject.filters.size shouldBe 1
-      assert(searchObject.filters.contains(ApplicationTextSearch))
-      searchObject.textToSearch shouldBe searchText
+      searchObject.filters should contain (ApplicationTextSearch)
+      searchObject.textToSearch shouldBe Some(searchText)
     }
 
     "correctly parse API Subscriptions filter" in {
@@ -62,7 +54,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, expectedFilters = Set(OneOrMoreAPISubscriptions))
+      searchObject.filters should contain (OneOrMoreAPISubscriptions)
     }
 
     "correctly parse Application Status filter" in {
@@ -70,7 +62,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, expectedFilters = Set(PendingGatekeeperCheck))
+      searchObject.filters should contain (PendingGatekeeperCheck)
     }
 
     "correctly parse Terms of Use filter" in {
@@ -78,7 +70,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, expectedFilters = Set(TermsOfUseNotAccepted))
+      searchObject.filters should contain (TermsOfUseNotAccepted)
     }
 
     "correctly parse Access Type filter" in {
@@ -86,7 +78,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, expectedFilters = Set(PrivilegedAccess))
+      searchObject.filters should contain (PrivilegedAccess)
     }
 
     "correctly parses multiple filters" in {
@@ -111,14 +103,9 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(
-        searchObject,
-        expectedPageNumber,
-        expectedPageSize,
-        Set(SpecificAPISubscription, Created, TermsOfUseAccepted, ROPCAccess, ApplicationTextSearch),
-        expectedSearchText,
-        expectedAPIContext,
-        expectedAPIVersion)
+      searchObject.filters should contain (SpecificAPISubscription)
+      searchObject.filters should contain (Created)
+      searchObject.filters should contain (TermsOfUseAccepted)
     }
 
     "not return a filter where apiSubscription is included with empty string" in {
@@ -126,7 +113,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(searchObject, expectedFilters = Set.empty)
+      searchObject.filters shouldBe empty
     }
 
     "populate apiContext if specific value is provided" in {
@@ -135,8 +122,8 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(
-        searchObject, expectedFilters = Set(SpecificAPISubscription), expectedAPIContext = api)
+      searchObject.apiContext shouldBe Some(api)
+      searchObject.filters should contain (SpecificAPISubscription)
     }
 
     "populate apiContext and apiVersion if specific values are provided" in {
@@ -146,27 +133,9 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
 
       val searchObject = ApplicationSearch.fromRequest(request)
 
-      checkCreatedSearchObject(
-        searchObject,
-        expectedFilters = Set(SpecificAPISubscription),
-        expectedAPIContext = api,
-        expectedAPIVersion = apiVersion)
+      searchObject.filters should contain (SpecificAPISubscription)
+      searchObject.apiContext shouldBe Some(api)
+      searchObject.apiVersion shouldBe Some(apiVersion)
     }
-  }
-
-  def checkCreatedSearchObject(searchObject: ApplicationSearch,
-                               expectedPageNumber: Int = 1,
-                               expectedPageSize: Int = Int.MaxValue,
-                               expectedFilters: Set[ApplicationSearchFilter] = Set.empty,
-                               expectedSearchText: String = "",
-                               expectedAPIContext: String = "",
-                               expectedAPIVersion: String = ""): Unit = {
-    searchObject.pageNumber shouldEqual expectedPageNumber
-    searchObject.pageSize shouldEqual expectedPageSize
-    searchObject.filters.size shouldEqual expectedFilters.size
-    searchObject.filters.toSet shouldEqual expectedFilters
-    searchObject.textToSearch shouldEqual expectedSearchText
-    searchObject.apiContext shouldEqual expectedAPIContext
-    searchObject.apiVersion shouldEqual expectedAPIVersion
   }
 }

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -41,7 +41,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val expectedPageSize: Int = 50
       val request = FakeRequest("GET", s"/applications?page=$expectedPageNumber&pageSize=$expectedPageSize")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(searchObject, expectedPageNumber, expectedPageSize, Set.empty)
     }
@@ -50,16 +50,16 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val searchText = "foo"
       val request = FakeRequest("GET", s"/applications?search=$searchText")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       searchObject.filters.size shouldBe 0
       searchObject.textToSearch shouldBe searchText
     }
 
     "correctly parse API Subscriptions filter" in {
-      val request = FakeRequest("GET", s"/applications?apiSubscriptions=ANYSUB")
+      val request = FakeRequest("GET", s"/applications?apiSubscription=ANYSUB")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(OneOrMoreAPISubscriptions))
     }
@@ -67,7 +67,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse Application Status filter" in {
       val request = FakeRequest("GET", s"/applications?status=PENDING_GATEKEEPER_CHECK")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(PendingGatekeeperCheck))
     }
@@ -75,7 +75,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse Terms of Use filter" in {
       val request = FakeRequest("GET", s"/applications?termsOfUse=TOU_NOT_ACCEPTED")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(TermsOfUseNotAccepted))
     }
@@ -83,7 +83,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse Access Type filter" in {
       val request = FakeRequest("GET", s"/applications?accessType=ACCESS_TYPE_PRIVILEGED")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(PrivilegedAccess))
     }
@@ -95,14 +95,14 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
         FakeRequest(
           "GET",
           s"/applications" +
-            s"?apiSubscriptions=NOSUB" +
+            s"?apiSubscription=NOSUB" +
             s"&status=CREATED" +
             s"&termsOfUse=TOU_ACCEPTED" +
             s"&accessType=ACCESS_TYPE_ROPC" +
             s"&page=$expectedPageNumber" +
             s"&pageSize=$expectedPageSize")
 
-      val searchObject = new ApplicationSearch(request)
+      val searchObject = ApplicationSearch.fromRequest(request)
 
       checkCreatedSearchObject(
         searchObject,
@@ -110,6 +110,8 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
         expectedPageSize,
         Set(NoAPISubscriptions, Created, TermsOfUseAccepted, ROPCAccess))
     }
+
+
   }
 
   def checkCreatedSearchObject(searchObject: ApplicationSearch,

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import uk.gov.hmrc.thirdpartyapplication.models._
 
 
-class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with MockitoSugar with Matchers {
+class ApplicationSearchSpec extends UnitSpec with MockitoSugar with Matchers {
 
   "ApplicationSearch" should {
 
@@ -32,7 +32,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val expectedPageSize: Int = 50
       val request = FakeRequest("GET", s"/applications?page=$expectedPageNumber&pageSize=$expectedPageSize")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.pageNumber shouldBe expectedPageNumber
       searchObject.pageSize shouldBe expectedPageSize
@@ -42,7 +42,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val searchText = "foo"
       val request = FakeRequest("GET", s"/applications?search=$searchText")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters.size shouldBe 1
       searchObject.filters should contain (ApplicationTextSearch)
@@ -52,7 +52,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse API Subscriptions filter" in {
       val request = FakeRequest("GET", s"/applications?apiSubscription=ANY")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters should contain (OneOrMoreAPISubscriptions)
     }
@@ -60,7 +60,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse Application Status filter" in {
       val request = FakeRequest("GET", s"/applications?status=PENDING_GATEKEEPER_CHECK")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters should contain (PendingGatekeeperCheck)
     }
@@ -68,7 +68,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse Terms of Use filter" in {
       val request = FakeRequest("GET", s"/applications?termsOfUse=NOT_ACCEPTED")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters should contain (TermsOfUseNotAccepted)
     }
@@ -76,7 +76,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "correctly parse Access Type filter" in {
       val request = FakeRequest("GET", s"/applications?accessType=PRIVILEGED")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters should contain (PrivilegedAccess)
     }
@@ -101,7 +101,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
             s"&page=$expectedPageNumber" +
             s"&pageSize=$expectedPageSize")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters should contain (SpecificAPISubscription)
       searchObject.filters should contain (Created)
@@ -111,7 +111,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
     "not return a filter where apiSubscription is included with empty string" in {
       val request = FakeRequest("GET", "/applications?apiSubscription=")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters shouldBe empty
     }
@@ -120,7 +120,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val api = "foo"
       val request = FakeRequest("GET", s"/applications?apiSubscription=$api")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.apiContext shouldBe Some(api)
       searchObject.filters should contain (SpecificAPISubscription)
@@ -131,7 +131,7 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       val apiVersion = "1.0"
       val request = FakeRequest("GET", s"/applications?apiSubscription=$api&apiVersion=$apiVersion")
 
-      val searchObject = ApplicationSearch.fromRequest(request)
+      val searchObject = ApplicationSearch.fromQueryString(request.queryString)
 
       searchObject.filters should contain (SpecificAPISubscription)
       searchObject.apiContext shouldBe Some(api)

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -111,7 +111,36 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
         Set(NoAPISubscriptions, Created, TermsOfUseAccepted, ROPCAccess))
     }
 
+    "not return a filter where apiSubscription is included with empty string" in {
+      val request = FakeRequest("GET", "/applications?apiSubscription=")
 
+      val searchObject = ApplicationSearch.fromRequest(request)
+
+      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set.empty)
+    }
+
+    "populate apiContext if specific value is provided" in {
+      val api = "foo"
+      val request = FakeRequest("GET", s"/applications?apiSubscription=$api")
+
+      val searchObject = ApplicationSearch.fromRequest(request)
+
+      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(SpecificAPISubscription))
+      searchObject.apiContext shouldBe api
+      searchObject.apiVersion shouldBe ""
+    }
+
+    "populate apiContext and apiVersion if specific values are provided" in {
+      val api = "foo"
+      val apiVersion = "1.0"
+      val request = FakeRequest("GET", s"/applications?apiSubscription=$api&apiVersion=$apiVersion")
+
+      val searchObject = ApplicationSearch.fromRequest(request)
+
+      checkCreatedSearchObject(searchObject, ApplicationSearch.DefaultPageNumber, ApplicationSearch.DefaultPageSize, Set(SpecificAPISubscription))
+      searchObject.apiContext shouldBe api
+      searchObject.apiVersion shouldBe apiVersion
+    }
   }
 
   def checkCreatedSearchObject(searchObject: ApplicationSearch,

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -46,6 +46,16 @@ class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with Mocki
       checkCreatedSearchObject(searchObject, expectedPageNumber, expectedPageSize, Set.empty)
     }
 
+    "correctly parse search text filter" in {
+      val searchText = "foo"
+      val request = FakeRequest("GET", s"/applications?search=$searchText")
+
+      val searchObject = new ApplicationSearch(request)
+
+      searchObject.filters.size shouldBe 0
+      searchObject.textToSearch shouldBe searchText
+    }
+
     "correctly parse API Subscriptions filter" in {
       val request = FakeRequest("GET", s"/applications?apiSubscriptions=ANYSUB")
 

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -19,7 +19,7 @@ package unit.uk.gov.hmrc.thirdpartyapplication.models
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 import play.api.test.FakeRequest
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.thirdpartyapplication.models._
 
 

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearchSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.uk.gov.hmrc.thirdpartyapplication.models
+
+import org.scalatest.mockito.MockitoSugar
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.thirdpartyapplication.models._
+
+
+class ApplicationSearchSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
+
+  "ApplicationSearch" should {
+    "correctly parse page number and size" in {
+      val expectedPageNumber: Int = 2
+      val expectedPageSize: Int = 50
+      val request = FakeRequest("GET", s"/applications?page=$expectedPageNumber&pageSize=$expectedPageSize")
+
+      val searchObject = new ApplicationSearch(request)
+
+      assert(searchObject.pageNumber == expectedPageNumber)
+      assert(searchObject.pageSize == expectedPageSize)
+      assert(searchObject.filters.isEmpty)
+    }
+
+    "correctly parse API Subscriptions filter" in {
+      val expectedPageNumber: Int = 1
+      val expectedPageSize: Int = 100
+      val request = FakeRequest("GET", s"/applications?apiSubscriptions=ANYSUB&page=$expectedPageNumber&pageSize=$expectedPageSize")
+
+      val searchObject = new ApplicationSearch(request)
+
+      assert(searchObject.pageNumber == expectedPageNumber)
+      assert(searchObject.pageSize == expectedPageSize)
+      assert(searchObject.filters.size == 1)
+      assert(searchObject.filters.contains(OneOrMoreAPISubscriptions))
+    }
+
+    "correctly parse Application Status filter" in {
+      val expectedPageNumber: Int = 1
+      val expectedPageSize: Int = 100
+      val request = FakeRequest("GET", s"/applications?status=PENDING_GATEKEEPER_CHECK&page=$expectedPageNumber&pageSize=$expectedPageSize")
+
+      val searchObject = new ApplicationSearch(request)
+
+      assert(searchObject.pageNumber == expectedPageNumber)
+      assert(searchObject.pageSize == expectedPageSize)
+      assert(searchObject.filters.size == 1)
+      assert(searchObject.filters.contains(PendingGatekeeperCheck))
+    }
+
+    "correctly parse Terms of Use filter" in {
+      val expectedPageNumber: Int = 1
+      val expectedPageSize: Int = 100
+      val request = FakeRequest("GET", s"/applications?termsOfUse=TOU_NOT_ACCEPTED&page=$expectedPageNumber&pageSize=$expectedPageSize")
+
+      val searchObject = new ApplicationSearch(request)
+
+      assert(searchObject.pageNumber == expectedPageNumber)
+      assert(searchObject.pageSize == expectedPageSize)
+      assert(searchObject.filters.size == 1)
+      assert(searchObject.filters.contains(TermsOfUseNotAccepted))
+    }
+
+    "correctly parse Access Type filter" in {
+      val expectedPageNumber: Int = 1
+      val expectedPageSize: Int = 100
+      val request = FakeRequest("GET", s"/applications?accessType=ACCESS_TYPE_PRIVILEGED&page=$expectedPageNumber&pageSize=$expectedPageSize")
+
+      val searchObject = new ApplicationSearch(request)
+
+      assert(searchObject.pageNumber == expectedPageNumber)
+      assert(searchObject.pageSize == expectedPageSize)
+      assert(searchObject.filters.size == 1)
+      assert(searchObject.filters.contains(PrivilegedAccess))
+    }
+
+    "correctly parses multiple filters" in {
+      val expectedPageNumber: Int = 1
+      val expectedPageSize: Int = 100
+      val request =
+        FakeRequest(
+          "GET",
+          s"/applications" +
+            s"?apiSubscriptions=NOSUB" +
+            s"&status=CREATED" +
+            s"&termsOfUse=TOU_ACCEPTED" +
+            s"&accessType=ACCESS_TYPE_ROPC" +
+            s"&page=$expectedPageNumber" +
+            s"&pageSize=$expectedPageSize")
+
+      val searchObject = new ApplicationSearch(request)
+
+      assert(searchObject.pageNumber == expectedPageNumber)
+      assert(searchObject.pageSize == expectedPageSize)
+      assert(searchObject.filters.contains(NoAPISubscriptions))
+      assert(searchObject.filters.contains(Created))
+      assert(searchObject.filters.contains(TermsOfUseAccepted))
+      assert(searchObject.filters.contains(ROPCAccess))
+    }
+  }
+}

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/services/ApplicationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/services/ApplicationServiceSpec.scala
@@ -1175,6 +1175,23 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
     }
   }
 
+  "Search" should {
+    "return results based on provided ApplicationSearch" in new Setup {
+      val standardApplicationData = anApplicationData(UUID.randomUUID(), access = Standard())
+      val privilegedApplicationData = anApplicationData(UUID.randomUUID(), access = Privileged())
+      val ropcApplicationData = anApplicationData(UUID.randomUUID(), access = Ropc())
+
+      val mockApplicationSearch: ApplicationSearch = mock[ApplicationSearch]
+
+      when(mockApplicationRepository.searchApplications(mockApplicationSearch))
+        .thenReturn(successful(Seq(standardApplicationData, privilegedApplicationData, ropcApplicationData)))
+
+      val results = await(underTest.searchApplications(mockApplicationSearch))
+
+      assert(results.size == 3)
+    }
+  }
+
   private def aNewApplicationRequest(access: Access = Standard(), environment: Environment = Environment.PRODUCTION) = {
     CreateApplicationRequest("MyApp", access, Some("description"), environment,
       Set(Collaborator(loggedInUser, ADMINISTRATOR)))


### PR DESCRIPTION
Introduced a new endpoint to the service, ahead of changes to [api-gatekeeper-frontend](https://github.com/hmrc/api-gatekeeper-frontend) to move searching to the server-side (rather than handled in the browser with JavaScript).

The new endpoint supports `GET` requests to `/applications` with some combination of the following query parameters:

Parameter Name | Data Type/Allowed Values |Description
----------------------|-----------------------------------|--------------
`search` | Free Text | Search application names and identifiers
`status` | `CREATED`, `PENDING_GATEKEEPER_CHECK`, `PENDING_SUBMITTER_VERIFICATION`, `ACTIVE` | Retrieve applications based on lifecycle status
`termsOfUse` | `ACCEPTED`, `NOT_ACCEPTED` | Whether owner of application has accepted relevant Terms of Use
`accessType` | `STANDARD`, `ROPC`, `PRIVILEGED` | Access type that application uses
`apiSubscription` | `ANY`, `NONE`, or specific API name | Which API application is subscribed to
`apiVersion` | Version Number | Version of the specific API that application is subscribed to 
`page` | Number | The page number to display (based on `pageSize`)
`pageSize` | Number | The maximum number of results to return

All existing endpoints remain in place, so existing upstream services should continue to work as normal.