### PR TITLE
Addressed issue where integration tests were intermittently failing.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -142,7 +142,7 @@ Dev {
   trustedApplications = []
 
   mongodb {
-    uri = "mongodb://localhost:27017/third-party-application?rm.monitorRefreshMS=4000&rm.failover=default"
+    uri = "mongodb://localhost:27017/third-party-application?rm.monitorRefreshMS=15000&rm.failover=default"
   }
 
   upliftVerificationExpiryJob {
@@ -242,7 +242,7 @@ Test {
   trustedApplications = [162017dc-607b-4405-8208-a28308672f76, 162017dc-607b-4405-8208-a28308672f77]
 
   mongodb {
-    uri = "mongodb://localhost:27017/third-party-application-test?rm.monitorRefreshMS=4000&rm.failover=default"
+    uri = "mongodb://localhost:27017/third-party-application-test?rm.monitorRefreshMS=15000&rm.failover=default"
   }
 
   upliftVerificationExpiryJob {


### PR DESCRIPTION
Integration tests that use Mongo were sometimes failing with an underlying error of:
"Timeout after 8200 milliseconds while probing the connection monitor: IsPrimaryAvailable#"
This possibly only occurs on Macs running Mojave.