### PR TITLE
APIS-4455 Applications now always have environment as PRODUCTION

### DIFF
--- a/app/uk/gov/hmrc/thirdpartyapplication/models/Application.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/Application.scala
@@ -106,7 +106,7 @@ case class ApplicationResponse(id: UUID,
 
 object ApplicationResponse {
 
-  def apply(data: ApplicationData, clientId: Option[String], trusted: Boolean): ApplicationResponse = {
+  def apply(data: ApplicationData, trusted: Boolean) : ApplicationResponse = {
     val redirectUris = data.access match {
       case a: Standard => a.redirectUris
       case _ => Seq()
@@ -134,7 +134,7 @@ object ApplicationResponse {
       termsAndConditionsUrl,
       privacyPolicyUrl,
       data.access,
-      Environment.from(data.environment),
+      Some(Environment.PRODUCTION),
       data.state,
       data.rateLimitTier.getOrElse(BRONZE),
       trusted,
@@ -234,20 +234,16 @@ case class Wso2Credentials(clientId: String,
 object Role extends Enumeration {
   type Role = Value
   val DEVELOPER, ADMINISTRATOR = Value
-
 }
 
 object Environment extends Enumeration {
   type Environment = Value
   val PRODUCTION, SANDBOX = Value
-
-  def from(env: String) = Environment.values.find(e => e.toString == env.toUpperCase)
 }
 
 object State extends Enumeration {
   type State = Value
   val TESTING, PENDING_GATEKEEPER_APPROVAL, PENDING_REQUESTER_VERIFICATION, PRODUCTION = Value
-
 }
 
 case class ApplicationState(name: State = TESTING, requestedByEmailAddress: Option[String] = None,
@@ -292,7 +288,7 @@ case class ApplicationState(name: State = TESTING, requestedByEmailAddress: Opti
 class ApplicationResponseCreator @Inject()(trustedApplications: TrustedApplications) {
 
   def createApplicationResponse(applicationData: ApplicationData, totpSecrets: Option[TotpSecrets]) = {
-    CreateApplicationResponse(ApplicationResponse(applicationData, None, trustedApplications.isTrusted(applicationData)), totpSecrets)
+    CreateApplicationResponse(ApplicationResponse(applicationData, trustedApplications.isTrusted(applicationData)), totpSecrets)
   }
 }
 

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
@@ -78,14 +78,14 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
   }
 
   def update[T <: ApplicationRequest](id: UUID, application: T)(implicit hc: HeaderCarrier): Future[ApplicationResponse] = {
-    updateApp(id)(application) map (app => ApplicationResponse(data = app, clientId = None, trusted = trustedApplications.isTrusted(app)))
+    updateApp(id)(application) map (app => ApplicationResponse(data = app, trusted = trustedApplications.isTrusted(app)))
   }
 
   def updateCheck(id: UUID, checkInformation: CheckInformation): Future[ApplicationResponse] = {
     for {
       existing <- fetchApp(id)
       savedApp <- applicationRepository.save(existing.copy(checkInformation = Some(checkInformation)))
-    } yield ApplicationResponse(data = savedApp, clientId = None, trusted = trustedApplications.isTrusted(savedApp))
+    } yield ApplicationResponse(data = savedApp, trusted = trustedApplications.isTrusted(savedApp))
   }
 
   def addCollaborator(applicationId: UUID, request: AddCollaboratorRequest)(implicit hc: HeaderCarrier) = {
@@ -215,61 +215,61 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
 
   def fetchByClientId(clientId: String): Future[Option[ApplicationResponse]] = {
     applicationRepository.fetchByClientId(clientId) map {
-      _.map(application => ApplicationResponse(data = application, clientId = Some(clientId), trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def recordApplicationUsage(applicationId: UUID): Future[ApplicationResponse] =
     applicationRepository.recordApplicationUsage(applicationId)
       .map(application =>
-        ApplicationResponse(data = application, clientId = Some(application.id.toString), trusted = trustedApplications.isTrusted(application)))
+        ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
 
   def fetchByServerToken(serverToken: String): Future[Option[ApplicationResponse]] = {
     applicationRepository.fetchByServerToken(serverToken) map {
       _.map(application =>
-        ApplicationResponse(data = application, clientId = Some(application.id.toString), trusted = trustedApplications.isTrusted(application)))
+        ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetchAllForCollaborator(emailAddress: String): Future[Seq[ApplicationResponse]] = {
     applicationRepository.fetchAllForEmailAddress(emailAddress).map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetchAllForCollaboratorAndEnvironment(emailAddress: String, environment: String): Future[Seq[ApplicationResponse]] = {
     applicationRepository.fetchAllForEmailAddressAndEnvironment(emailAddress, environment).map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetchAll(): Future[Seq[ApplicationResponse]] = {
     applicationRepository.findAll().map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetchAllBySubscription(apiContext: String): Future[Seq[ApplicationResponse]] = {
     applicationRepository.fetchAllForContext(apiContext) map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetchAllBySubscription(apiIdentifier: APIIdentifier): Future[Seq[ApplicationResponse]] = {
     applicationRepository.fetchAllForApiIdentifier(apiIdentifier) map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetchAllWithNoSubscriptions(): Future[Seq[ApplicationResponse]] = {
     applicationRepository.fetchAllWithNoSubscriptions() map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
   def fetch(applicationId: UUID): Future[Option[ApplicationResponse]] = {
     applicationRepository.fetch(applicationId) map {
-      _.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application)))
+      _.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application)))
     }
   }
 
@@ -281,7 +281,7 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
         total = data.totals.foldLeft(0)(_ + _.total),
         matching = data.matching.foldLeft(0)(_ + _.total),
         applications =
-          data.applications.map(application => ApplicationResponse(data = application, clientId = None, trusted = trustedApplications.isTrusted(application))))
+          data.applications.map(application => ApplicationResponse(data = application, trusted = trustedApplications.isTrusted(application))))
     }
   }
 

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/CredentialService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/CredentialService.scala
@@ -41,7 +41,7 @@ class CredentialService @Inject()(applicationRepository: ApplicationRepository,
 
   def fetch(applicationId: UUID): Future[Option[ApplicationResponse]] = {
     applicationRepository.fetch(applicationId) map (_.map(
-      app => ApplicationResponse(data = app, clientId = None, trusted = trustedApplications.isTrusted(app))))
+      app => ApplicationResponse(data = app, trusted = trustedApplications.isTrusted(app))))
   }
 
   def fetchCredentials(applicationId: UUID): Future[Option[EnvironmentTokenResponse]] = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/GatekeeperService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/GatekeeperService.scala
@@ -75,9 +75,7 @@ class GatekeeperService @Inject()(applicationRepository: ApplicationRepository,
       app <- fetchApp(id)
       history <- stateHistoryRepository.fetchByApplicationId(id)
     } yield {
-      ApplicationWithHistory(ApplicationResponse(data = app,
-        clientId = None,
-        trusted = trustedApplications.isTrusted(app)),
+      ApplicationWithHistory(ApplicationResponse(data = app, trusted = trustedApplications.isTrusted(app)),
         history.map(StateHistoryResponse.from))
     }
   }

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/services/ApplicationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/services/ApplicationServiceSpec.scala
@@ -848,7 +848,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       val result = await(underTest.fetchAllBySubscription(apiContext))
 
       result.size shouldBe 1
-      result shouldBe Seq(applicationData).map(app => ApplicationResponse(data = app, clientId = None, trusted = false))
+      result shouldBe Seq(applicationData).map(app => ApplicationResponse(data = app, trusted = false))
     }
 
     "return no matching applications for a given subscription to an API context" in new Setup {
@@ -873,7 +873,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       val result = await(underTest.fetchAllBySubscription(apiIdentifier))
 
       result.size shouldBe 1
-      result shouldBe Seq(applicationData).map(app => ApplicationResponse(data = app, clientId = None, trusted = false))
+      result shouldBe Seq(applicationData).map(app => ApplicationResponse(data = app, trusted = false))
     }
 
     "return no matching applications for a given subscription to an API identifier" in new Setup {
@@ -913,7 +913,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       val result = await(underTest.fetchAllWithNoSubscriptions())
 
       result.size shouldBe 1
-      result shouldBe Seq(applicationData).map(app => ApplicationResponse(data = app, clientId = None, trusted = false))
+      result shouldBe Seq(applicationData).map(app => ApplicationResponse(data = app, trusted = false))
     }
   }
 

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/services/GatekeeperServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/services/GatekeeperServiceSpec.scala
@@ -151,7 +151,7 @@ class GatekeeperServiceSpec extends UnitSpec with ScalaFutures with MockitoSugar
 
       val result = await(underTest.fetchAppWithHistory(appId))
 
-      result shouldBe ApplicationWithHistory(ApplicationResponse(data = app1, clientId = None, trusted = false), history.map(StateHistoryResponse.from))
+      result shouldBe ApplicationWithHistory(ApplicationResponse(data = app1, trusted = false), history.map(StateHistoryResponse.from))
     }
 
     "throw not found exception" in new Setup {


### PR DESCRIPTION
Applications that were in the sandbox/subordinate environment where being returned from application endpoints with the environment property set to SANDBOX when the environment property in Mongo was SANDBOX.  This broke the token handling process because callers expected this value to be PRODUCTION (or at least did when fetching by Client ID).  This has been hardcoded to PRODUCTION because it doesn't seem to make sense for it to be anything else.