### PR TITLE
APIS-4386 Fixed bug with uplifting an app and name validation 

### DIFF
--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -171,7 +171,7 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
       withJsonBody[ApplicationNameValidationRequest] { applicationNameValidationRequest: ApplicationNameValidationRequest =>
 
         applicationService
-          .validateApplicationName(applicationNameValidationRequest.applicationName)
+          .validateApplicationName(applicationNameValidationRequest.applicationName, applicationNameValidationRequest.selfApplicationId)
           .map((result: ApplicationNameValidationResult) => {
 
             val json = result match {

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/Model.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/Model.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.thirdpartyapplication.controllers
 
+import java.util.UUID
+
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.thirdpartyapplication.models.{Collaborator, OverrideFlag}
 
 case class ValidationRequest(clientId: String, clientSecret: String)
-case class ApplicationNameValidationRequest(applicationName: String)
+case class ApplicationNameValidationRequest(applicationName: String, selfApplicationId: Option[UUID])
 
 case class ClientSecretRequest(name: String)
 

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -154,12 +154,12 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)
 
   def fetch(id: UUID): Future[Option[ApplicationData]] = find("id" -> id).map(_.headOption)
 
-  def fetchApplicationByName(name: String): Future[Option[ApplicationData]] = {
+  def fetchApplicationsByName(name: String): Future[Seq[ApplicationData]] = {
     val query: (String, JsValueWrapper) = f"$$and" -> Json.arr(
       Json.obj("normalisedName" -> name.toLowerCase)
     )
 
-    find(query).map(_.headOption)
+    find(query)
   }
 
   def fetchVerifiableUpliftBy(verificationCode: String): Future[Option[ApplicationData]] = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
@@ -312,10 +312,12 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
     } yield UpliftRequested
   }
 
-  private def assertAppHasUniqueNameAndAudit(submittedAppName: String, accessType: AccessType, existingApp: Option[ApplicationData] = None)
+  private def assertAppHasUniqueNameAndAudit(submittedAppName: String,
+                                             accessType: AccessType,
+                                             existingApp: Option[ApplicationData] = None)
                                             (implicit hc: HeaderCarrier) = {
     for {
-      duplicate <- isDuplicateName(submittedAppName)
+      duplicate <- isDuplicateName(submittedAppName, existingApp.map(_.id))
       _ = if (duplicate) {
         accessType match {
           case PRIVILEGED => auditService.audit(CreatePrivilegedApplicationRequestDeniedDueToNonUniqueName,
@@ -505,21 +507,27 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
     Future.successful(!isValid)
   }
 
-  private def isDuplicateName(applicationName: String)(implicit hc: HeaderCarrier): Future[Boolean] = {
-    if (nameValidationConfig.validateForDuplicateAppNames) {
-      applicationRepository
-        .fetchApplicationByName(applicationName)
-        .map(r => r.isDefined)
-    } else {
-      Future.successful(false)
+  private def isDuplicateName(applicationName: String, thisApplicationId: Option[UUID])(implicit hc: HeaderCarrier): Future[Boolean] = {
+
+    def isThisApplication(app: ApplicationData) = thisApplicationId.contains(app.id)
+
+    def anyDuplicatesExcludingThis(apps: Seq[ApplicationData]): Boolean = {
+      apps.exists(!isThisApplication(_))
     }
+
+    if (nameValidationConfig.validateForDuplicateAppNames)
+      applicationRepository
+        .fetchApplicationsByName(applicationName)
+        .map(anyDuplicatesExcludingThis)
+    else
+      Future.successful(false)
   }
 
   def validateApplicationName(applicationName: String)
                              (implicit hc: HeaderCarrier): Future[ApplicationNameValidationResult] = {
     for {
       isBlacklisted <- isBlacklistedName(applicationName)
-      isDuplicate <- isDuplicateName(applicationName)
+      isDuplicate <- isDuplicateName(applicationName, None)
     } yield (isBlacklisted, isDuplicate) match {
       case (false, false) => Valid
       case (blacklist, duplicate) => Invalid(blacklist, duplicate)

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/ApplicationService.scala
@@ -515,19 +515,20 @@ class ApplicationService @Inject()(applicationRepository: ApplicationRepository,
       apps.exists(!isThisApplication(_))
     }
 
-    if (nameValidationConfig.validateForDuplicateAppNames)
+    if (nameValidationConfig.validateForDuplicateAppNames) {
       applicationRepository
         .fetchApplicationsByName(applicationName)
         .map(anyDuplicatesExcludingThis)
-    else
+    } else {
       Future.successful(false)
+    }
   }
 
-  def validateApplicationName(applicationName: String)
+  def validateApplicationName(applicationName: String, selfApplicationId: Option[UUID])
                              (implicit hc: HeaderCarrier): Future[ApplicationNameValidationResult] = {
     for {
       isBlacklisted <- isBlacklistedName(applicationName)
-      isDuplicate <- isDuplicateName(applicationName, None)
+      isDuplicate <- isDuplicateName(applicationName, selfApplicationId)
     } yield (isBlacklisted, isDuplicate) match {
       case (false, false) => Valid
       case (blacklist, duplicate) => Invalid(blacklist, duplicate)

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepositorySpec.scala
@@ -301,9 +301,9 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
 
       await(applicationRepository.save(application))
 
-      val retrieved = await(applicationRepository.fetchApplicationByName(applicationName))
+      val retrieved = await(applicationRepository.fetchApplicationsByName(applicationName))
 
-      retrieved shouldBe Some(application)
+      retrieved shouldBe Seq(application)
     }
 
     "dont retrieve the application if it's a non-matching name" in {
@@ -314,9 +314,9 @@ class ApplicationRepositorySpec extends UnitSpec with MongoSpecSupport
 
       await(applicationRepository.save(application))
 
-      val retrieved = await(applicationRepository.fetchApplicationByName("non-matching-name"))
+      val retrieved = await(applicationRepository.fetchApplicationsByName("non-matching-name"))
 
-      retrieved shouldBe None
+      retrieved shouldBe Seq.empty
     }
   }
 

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationControllerSpec.scala
@@ -812,9 +812,10 @@ class ApplicationControllerSpec extends UnitSpec with ScalaFutures with MockitoS
     "Allow a valid app" in new Setup {
 
       val applicationName = "my valid app name"
-      val payload = s"""{"applicationName":"${applicationName}", "environment":"PRODUCTION"}"""
+      val appId = UUID.randomUUID()
+      val payload = s"""{"applicationName":"${applicationName}", "environment":"PRODUCTION", "selfApplicationId" : "${appId.toString}" }"""
 
-      when(mockApplicationService.validateApplicationName(any())(any[HeaderCarrier]))
+      when(mockApplicationService.validateApplicationName(any(), any())(any[HeaderCarrier]))
         .thenReturn(successful(Valid))
 
       private val result = await(underTest.validateApplicationName(request.withBody(Json.parse(payload))))
@@ -823,14 +824,31 @@ class ApplicationControllerSpec extends UnitSpec with ScalaFutures with MockitoS
 
       jsonBodyOf(result) shouldBe Json.obj()
 
-      verify(mockApplicationService).validateApplicationName(mockEq(applicationName))(any[HeaderCarrier])
+      verify(mockApplicationService).validateApplicationName(mockEq(applicationName), mockEq(Some(appId)))(any[HeaderCarrier])
+    }
+
+    "Allow a valid app with an optional selfApplicationId" in new Setup {
+      val applicationName = "my valid app name"
+      val appId = UUID.randomUUID()
+      val payload = s"""{"applicationName":"${applicationName}", "environment":"PRODUCTION"}"""
+
+      when(mockApplicationService.validateApplicationName(any(), any())(any[HeaderCarrier]))
+        .thenReturn(successful(Valid))
+
+      private val result = await(underTest.validateApplicationName(request.withBody(Json.parse(payload))))
+
+      status(result) shouldBe SC_OK
+
+      jsonBodyOf(result) shouldBe Json.obj()
+
+      verify(mockApplicationService).validateApplicationName(any(), mockEq(None))(any[HeaderCarrier])
     }
 
     "Reject an app name as it contains a block bit of text" in new Setup {
       val applicationName = "my invalid HMRC app name"
       val payload = s"""{"applicationName":"${applicationName}"}"""
 
-      when(mockApplicationService.validateApplicationName(any())(any[HeaderCarrier]))
+      when(mockApplicationService.validateApplicationName(any(), any())(any[HeaderCarrier]))
         .thenReturn(successful(Invalid.invalidName))
 
       private val result = await(underTest.validateApplicationName(request.withBody(Json.parse(payload))))
@@ -839,14 +857,14 @@ class ApplicationControllerSpec extends UnitSpec with ScalaFutures with MockitoS
 
       jsonBodyOf(result) shouldBe Json.obj("errors" -> Json.obj("invalidName" -> true, "duplicateName" -> false))
 
-      verify(mockApplicationService).validateApplicationName(mockEq(applicationName))(any[HeaderCarrier])
+      verify(mockApplicationService).validateApplicationName(mockEq(applicationName),mockEq(None))(any[HeaderCarrier])
     }
 
     "Reject an app name as it is a duplicate name" in new Setup {
       val applicationName = "my duplicate app name"
       val payload = s"""{"applicationName":"${applicationName}"}"""
 
-      when(mockApplicationService.validateApplicationName(any())(any[HeaderCarrier]))
+      when(mockApplicationService.validateApplicationName(any(),any())(any[HeaderCarrier]))
         .thenReturn(successful(Invalid.duplicateName))
 
       private val result = await(underTest.validateApplicationName(request.withBody(Json.parse(payload))))
@@ -855,7 +873,7 @@ class ApplicationControllerSpec extends UnitSpec with ScalaFutures with MockitoS
 
       jsonBodyOf(result) shouldBe Json.obj("errors" -> Json.obj("invalidName" -> false, "duplicateName" -> true))
 
-      verify(mockApplicationService).validateApplicationName(mockEq(applicationName))(any[HeaderCarrier])
+      verify(mockApplicationService).validateApplicationName(mockEq(applicationName),mockEq(None))(any[HeaderCarrier])
     }
   }
 

--- a/test/unit/uk/gov/hmrc/thirdpartyapplication/services/ApplicationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/thirdpartyapplication/services/ApplicationServiceSpec.scala
@@ -81,8 +81,8 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
     when(mockTrustedApplications.isTrusted(anApplicationData(trustedApplicationId1))).thenReturn(true)
     when(mockTrustedApplications.isTrusted(anApplicationData(trustedApplicationId2))).thenReturn(true)
 
-    when(mockApplicationRepository.fetchApplicationByName(any()))
-      .thenReturn(Future.successful(None))
+    when(mockApplicationRepository.fetchApplicationsByName(any()))
+      .thenReturn(Future.successful(Seq.empty))
 
     val applicationResponseCreator = new ApplicationResponseCreator(mockTrustedApplications)
 
@@ -256,7 +256,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
 
     "create a new Privileged application in Mongo and WSO2 with a Production state" in new Setup {
       val applicationRequest: CreateApplicationRequest = aNewApplicationRequest(access = Privileged())
-      when(mockApplicationRepository.fetchApplicationByName(applicationRequest.name)).thenReturn(None)
+      when(mockApplicationRepository.fetchApplicationsByName(applicationRequest.name)).thenReturn(Seq.empty)
 
       val prodTOTP = Totp("prodTotp", "prodTotpId")
       val sandboxTOTP = Totp("sandboxTotp", "sandboxTotpId")
@@ -289,7 +289,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
     "create a new ROPC application in Mongo and WSO2 with a Production state" in new Setup {
       val applicationRequest: CreateApplicationRequest = aNewApplicationRequest(access = Ropc())
 
-      when(mockApplicationRepository.fetchApplicationByName(applicationRequest.name)).thenReturn(None)
+      when(mockApplicationRepository.fetchApplicationsByName(applicationRequest.name)).thenReturn(Seq.empty)
 
       val createdApp: CreateApplicationResponse = await(underTest.create(applicationRequest)(hc))
 
@@ -309,7 +309,8 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
     "fail with ApplicationAlreadyExists for privileged application when the name already exists for another application not in testing mode" in new Setup {
       val applicationRequest: CreateApplicationRequest = aNewApplicationRequest(Privileged())
 
-      when(mockApplicationRepository.fetchApplicationByName(applicationRequest.name)).thenReturn(Some(anApplicationData(UUID.randomUUID())))
+      when(mockApplicationRepository.fetchApplicationsByName(applicationRequest.name))
+        .thenReturn(Seq(anApplicationData(UUID.randomUUID())))
 
       intercept[ApplicationAlreadyExists] {
         await(underTest.create(applicationRequest)(hc))
@@ -321,7 +322,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
     "fail with ApplicationAlreadyExists for ropc application when the name already exists for another application not in testing mode" in new Setup {
       val applicationRequest: CreateApplicationRequest = aNewApplicationRequest(Ropc())
 
-      when(mockApplicationRepository.fetchApplicationByName(applicationRequest.name)).thenReturn(Some(anApplicationData(UUID.randomUUID())))
+      when(mockApplicationRepository.fetchApplicationsByName(applicationRequest.name)).thenReturn(Seq(anApplicationData(UUID.randomUUID())))
 
       intercept[ApplicationAlreadyExists] {
         await(underTest.create(applicationRequest)(hc))
@@ -1056,8 +1057,8 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       when(mockNameValidationConfig.nameBlackList)
         .thenReturn(Seq.empty)
 
-      when(mockApplicationRepository.fetchApplicationByName(any()))
-        .thenReturn(Some(anApplicationData(applicationId = UUID.randomUUID())))
+      when(mockApplicationRepository.fetchApplicationsByName(any()))
+        .thenReturn(Seq(anApplicationData(applicationId = UUID.randomUUID())))
 
       private val duplicateName = "duplicate name"
       val result = await(underTest.validateApplicationName(duplicateName))
@@ -1065,26 +1066,25 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       result shouldBe Invalid.duplicateName
 
       verify(mockApplicationRepository)
-        .fetchApplicationByName(duplicateName)
+        .fetchApplicationsByName(duplicateName)
     }
 
     "Ignore duplicate name check if not configured e.g. on a subordinate / sandbox environment" in new Setup {
       when(mockNameValidationConfig.nameBlackList)
         .thenReturn(Seq.empty)
 
-      // TODO: Add to Dev & ET -> Override as false
       when(mockNameValidationConfig.validateForDuplicateAppNames)
         .thenReturn(false)
 
-      when(mockApplicationRepository.fetchApplicationByName(any()))
-        .thenReturn(Some(anApplicationData(applicationId = UUID.randomUUID())))
+      when(mockApplicationRepository.fetchApplicationsByName(any()))
+        .thenReturn(Seq(anApplicationData(applicationId = UUID.randomUUID())))
 
       val result = await(underTest.validateApplicationName("app name"))
 
       result shouldBe Valid
 
       verify(mockApplicationRepository, times(0))
-        .fetchApplicationByName(any())
+        .fetchApplicationsByName(any())
     }
   }
 
@@ -1097,11 +1097,14 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       val application: ApplicationData = anApplicationData(applicationId, testingState())
       val expectedApplication: ApplicationData = application.copy(state = pendingGatekeeperApprovalState(upliftRequestedBy),
         name = requestedName, normalisedName = requestedName.toLowerCase)
+
       val expectedStateHistory = StateHistory(applicationId = expectedApplication.id, state = PENDING_GATEKEEPER_APPROVAL,
         actor = Actor(upliftRequestedBy, COLLABORATOR), previousState = Some(TESTING))
 
       mockApplicationRepositoryFetchToReturn(applicationId, Some(application))
-      when(mockApplicationRepository.fetchApplicationByName(requestedName)).thenReturn(None)
+
+      when(mockApplicationRepository.fetchApplicationsByName(requestedName))
+        .thenReturn(Seq(application, expectedApplication))
 
       val result: ApplicationStateChange = await(underTest.requestUplift(applicationId, requestedName, upliftRequestedBy))
 
@@ -1114,8 +1117,12 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       val application: ApplicationData = anApplicationData(applicationId, testingState())
 
       mockApplicationRepositoryFetchToReturn(applicationId, Some(application))
-      when(mockApplicationRepository.fetchApplicationByName(requestedName)).thenReturn(None)
-      when(mockStateHistoryRepository.insert(any())).thenReturn(failed(new RuntimeException("Expected test failure")))
+
+      when(mockApplicationRepository.fetchApplicationsByName(requestedName))
+        .thenReturn(Seq(application))
+
+      when(mockStateHistoryRepository.insert(any()))
+        .thenReturn(failed(new RuntimeException("Expected test failure")))
 
       intercept[RuntimeException] {
         await(underTest.requestUplift(applicationId, requestedName, upliftRequestedBy))
@@ -1131,7 +1138,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
 
 
       mockApplicationRepositoryFetchToReturn(applicationId, Some(application))
-      when(mockApplicationRepository.fetchApplicationByName(application.name)).thenReturn(None)
+      when(mockApplicationRepository.fetchApplicationsByName(application.name)).thenReturn(Seq.empty)
 
       val result: ApplicationStateChange = await(underTest.requestUplift(applicationId, application.name, upliftRequestedBy))
       verify(mockAuditService).audit(ApplicationUpliftRequested, Map("applicationId" -> application.id.toString))
@@ -1144,7 +1151,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
 
 
       mockApplicationRepositoryFetchToReturn(applicationId, Some(application))
-      when(mockApplicationRepository.fetchApplicationByName(requestedName)).thenReturn(None)
+      when(mockApplicationRepository.fetchApplicationsByName(requestedName)).thenReturn(Seq.empty)
 
       val result: ApplicationStateChange = await(underTest.requestUplift(applicationId, requestedName, upliftRequestedBy))
 
@@ -1160,7 +1167,7 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       intercept[InvalidStateTransition] {
         await(underTest.requestUplift(applicationId, requestedName, upliftRequestedBy))
       }
-      verify(mockApplicationRepository, never).fetchApplicationByName(requestedName)
+      verify(mockApplicationRepository, never).fetchApplicationsByName(requestedName)
     }
 
     "fail with ApplicationAlreadyExists when another uplifted application already exist with the same name" in new Setup {
@@ -1168,13 +1175,13 @@ class ApplicationServiceSpec extends UnitSpec with ScalaFutures with MockitoSuga
       val anotherApplication: ApplicationData = anApplicationData(UUID.randomUUID(), productionState("admin@example.com"))
 
       mockApplicationRepositoryFetchToReturn(applicationId, Some(application))
-      when(mockApplicationRepository.fetchApplicationByName(requestedName)).thenReturn(Some(anotherApplication))
+
+      when(mockApplicationRepository.fetchApplicationsByName(requestedName))
+        .thenReturn(Seq(application,anotherApplication))
 
       intercept[ApplicationAlreadyExists] {
         await(underTest.requestUplift(applicationId, requestedName, upliftRequestedBy))
       }
-      val expectedAuditDetails: Map[String, String] = Map("applicationId" -> application.id.toString, "applicationName" -> requestedName)
-      verify(mockAuditService).audit(ApplicationUpliftRequestDeniedDueToNonUniqueName, expectedAuditDetails)
     }
 
     "propagate the exception when the repository fail" in new Setup {


### PR DESCRIPTION
APIS-4386 - Fixed bug when uplifting an app failed as it thought itself was a duplicate name.

Now ignores itself when checking for a duplicate name
