### PR TITLE
APSR-1161 - Updated reactive-mongo dependency to 0.18.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,15 +10,18 @@ lazy val appName = "third-party-application"
 
 lazy val appDependencies: Seq[ModuleID] = compile ++ test ++ tmpMacWorkaround
 
+val reactiveMongoVer = "0.18.8"
+
 lazy val compile = Seq(
   "uk.gov.hmrc" %% "bootstrap-play-25" % "4.13.0",
-  "uk.gov.hmrc" %% "mongo-lock" % "6.15.0-play-25",
-  "uk.gov.hmrc" %% "play-scheduling" % "6.0.0",
+  "uk.gov.hmrc" %% "play-scheduling" % "7.1.0-play-25",
   "uk.gov.hmrc" %% "play-json-union-formatter" % "1.7.0",
   "uk.gov.hmrc" %% "play-hmrc-api" % "3.6.0-play-25",
   "uk.gov.hmrc" %% "metrix" % "3.8.0-play-25",
-  "com.typesafe.play" %% "play-iteratees" % PlayVersion.current,
-  "org.reactivemongo" %% "reactivemongo-iteratees" % "0.16.4",
+  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.21.0-play-25",
+  "org.reactivemongo" %% "reactivemongo-iteratees" % reactiveMongoVer,
+  "org.reactivemongo" %% "play2-reactivemongo" % (reactiveMongoVer + "-play25"),
+  "org.reactivemongo" %% "reactivemongo-play-json" % (reactiveMongoVer + "-play25"),
   "commons-net" % "commons-net" % "3.6"
 )
 lazy val test = Seq(

--- a/run_all_tests_no_coverage.sh
+++ b/run_all_tests_no_coverage.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 mongo third-party-application-test --eval "db.dropDatabase()"
+export SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=1G"
 sbt clean compile test it:test
 python dependencyReport.py third-party-application

--- a/test/it/uk/gov/hmrc/thirdpartyapplication/component/ThirdPartyApplicationComponentSpec.scala
+++ b/test/it/uk/gov/hmrc/thirdpartyapplication/component/ThirdPartyApplicationComponentSpec.scala
@@ -433,14 +433,15 @@ class ThirdPartyApplicationComponentSpec extends BaseFeatureSpec {
       apiDefinition.willReturnApisForApplication(application.id, Seq(anApiDefinition))
 
       And("The application is subscribed to an API")
-      subscriptionExists(application.id, context, version)
+      result(subscriptionExists(application.id, context, version),timeout)
 
       When("I fetch the API subscriptions of the application")
       val response = Http(s"$serviceUrl/application/${application.id}/subscription").asString
 
       Then("The API subscription is returned")
-      val result = Json.parse(response.body).as[Seq[ApiSubscription]]
-      result shouldBe Seq(ApiSubscription(apiName, serviceName, context, Seq(VersionSubscription(anApiDefinition.versions.head, subscribed = true))))
+      val actualApiSubscription = Json.parse(response.body).as[Seq[ApiSubscription]]
+      actualApiSubscription shouldBe
+        Seq(ApiSubscription(apiName, serviceName, context, Seq(VersionSubscription(anApiDefinition.versions.head, subscribed = true))))
     }
 
     scenario("Fetch All API Subscriptions") {


### PR DESCRIPTION
 - Also updated other dependencies
 - Fixed occasionally failing test (not waiting for a future to complete)
 - Fixed index comparison
 - Fixed memory when running tests with no coverage