### PR TITLE
APSR-1271 - Stop using USER-AGENT header internally

### DIFF
--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -55,8 +55,10 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
   val subscriptionCacheExpiry = config.fetchSubscriptionTtlInSecs
 
   val apiGatewayUserAgent: String = "APIPlatformAuthorizer"
-  val INTERNAL_USER_AGENT = "X-GATEWAY-USER-AGENT"
-
+  // This header is not expected to reach outside but is used to pass information further down the call stack.
+  // TODO - tidy this up to use a better way to decorate calls with the knowledge they came from API Gateway (or not)
+val INTERNAL_USER_AGENT = "X-GATEWAY-USER-AGENT"
+  
   override implicit def hc(implicit request: RequestHeader) = {
     def header(key: String) = request.headers.get(key) map (key -> _)
     def renamedHeader(key: String, newKey: String) = request.headers.get(key) map (newKey -> _)

--- a/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/controllers/ApplicationController.scala
@@ -55,7 +55,7 @@ class ApplicationController @Inject()(val applicationService: ApplicationService
   val subscriptionCacheExpiry = config.fetchSubscriptionTtlInSecs
 
   val apiGatewayUserAgent: String = "APIPlatformAuthorizer"
-  val INTERNAL_USER_AGENT = "X-GATEWAY_USER_AGENT"
+  val INTERNAL_USER_AGENT = "X-GATEWAY-USER-AGENT"
 
   override implicit def hc(implicit request: RequestHeader) = {
     def header(key: String) = request.headers.get(key) map (key -> _)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -56,7 +56,7 @@ play.modules.enabled += "uk.gov.hmrc.thirdpartyapplication.metrics.MetricsModule
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret = "3kXCHYnjCIvNeJa6KHrpNy6z8tLGqTtMMls0V5ypVihNd3irhDk47ctKmGXluPlz"
+play.http.secret.key = "3kXCHYnjCIvNeJa6KHrpNy6z8tLGqTtMMls0V5ypVihNd3irhDk47ctKmGXluPlz"
 
 # Session configuration
 # ~~~~~

--- a/it/uk/gov/hmrc/thirdpartyapplication/repository/SubscriptionRepositorySpec.scala
+++ b/it/uk/gov/hmrc/thirdpartyapplication/repository/SubscriptionRepositorySpec.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.thirdpartyapplication.repository
 
-import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import uk.gov.hmrc.thirdpartyapplication.ApplicationStateUtil
@@ -31,7 +29,6 @@ import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 import uk.gov.hmrc.thirdpartyapplication.models._
 import uk.gov.hmrc.thirdpartyapplication.models.UserId
 import uk.gov.hmrc.thirdpartyapplication.models.db.{ApplicationData, ApplicationTokens}
-import uk.gov.hmrc.thirdpartyapplication.repository.{ApplicationRepository, SubscriptionRepository}
 import uk.gov.hmrc.thirdpartyapplication.util.AsyncHmrcSpec
 import uk.gov.hmrc.time.DateTimeUtils
 


### PR DESCRIPTION
USER_AGENT was been copied forward for the purpose of recording api use from the gateway.  In order to prevent confusion in any calls external, we have renamed the header to X-GATEWAY-USER-AGENT for internal purposes.