### PR TITLE
APIS-5542 : Performance fix for application search aggregate query.

### DIFF
--- a/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/models/ApplicationSearch.scala
@@ -30,7 +30,9 @@ case class ApplicationSearch(pageNumber: Int = 1,
                              textToSearch: Option[String] = None,
                              apiContext: Option[ApiContext] = None,
                              apiVersion: Option[ApiVersion] = None,
-                             sort: ApplicationSort = SubmittedAscending)
+                             sort: ApplicationSort = SubmittedAscending){
+                               def hasSubscriptionFilter() = filters.exists(filter => filter.isInstanceOf[APISubscriptionFilter])
+                             }
 
 object ApplicationSearch {
   def fromQueryString(queryString: Map[String, Seq[String]]): ApplicationSearch = {

--- a/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/repository/ApplicationRepository.scala
@@ -248,7 +248,7 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)(implicit va
       Json.obj(f"$$skip" -> (applicationSearch.pageNumber - 1) * applicationSearch.pageSize),
       Json.obj(f"$$limit" -> applicationSearch.pageSize))
 
-    runApplicationQueryAggregation(commandQueryDocument(filters, pagination, sort))
+    runApplicationQueryAggregation(commandQueryDocument(filters, pagination, sort, applicationSearch.hasSubscriptionFilter()))
   }
 
   private def matches(predicates: (String, JsValueWrapper)): JsObject = Json.obj(f"$$match" -> Json.obj(predicates))
@@ -335,10 +335,15 @@ class ApplicationRepository @Inject()(mongo: ReactiveMongoComponent)(implicit va
     }
   }
 
-  private def commandQueryDocument(filters: List[JsObject], pagination: List[JsObject], sort: List[JsObject]): JsObject = {
+  private def commandQueryDocument(filters: List[JsObject], pagination: List[JsObject], sort: List[JsObject], hasSubscriptionsQuery: Boolean): JsObject = {
     val totalCount = Json.arr(Json.obj(f"$$count" -> "total"))
-    val filteredPipelineCount = Json.toJson(subscriptionsLookup +: filters :+ Json.obj(f"$$count" -> "total"))
-    val paginatedFilteredAndSortedPipeline = Json.toJson((subscriptionsLookup +: filters) ++ sort ++ pagination :+ applicationProjection)
+    
+    val subscriptionsLookupFilter = if (hasSubscriptionsQuery) {
+      Seq(subscriptionsLookup)
+    } else Seq.empty
+
+    val filteredPipelineCount = Json.toJson(subscriptionsLookupFilter ++ filters :+ Json.obj(f"$$count" -> "total"))
+    val paginatedFilteredAndSortedPipeline = Json.toJson((subscriptionsLookupFilter ++ filters) ++ sort ++ pagination :+ applicationProjection)
 
     Json.obj(
       "aggregate" -> "application",


### PR DESCRIPTION
 The applicaiton search applicaiton query often fails when it hits the 100mb MongoDb sort limit. This is due to it 'joining' in the applicaitons subscriptions for all queryes.
This fix now only 'joins' the subscriptions IF the query is related to a specific subscription.