### PR TITLE
API-6649 - Fix email connector breaking on no recipients

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -31,7 +31,7 @@ newlines.implicitParamListModifierPrefer = before
 newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
 
 rewrite.rules = [SortModifiers]
-rewrite.rules = [SortImports]
+rewrite.rules = [AsciiSortImports]
 
 verticalMultiline.atDefnSite = true
 verticalMultiline.newlineAfterOpenParen = true

--- a/app/uk/gov/hmrc/apiplatform/modules/approvals/controllers/ApprovalsController.scala
+++ b/app/uk/gov/hmrc/apiplatform/modules/approvals/controllers/ApprovalsController.scala
@@ -122,7 +122,8 @@ class ApprovalsController @Inject() (
       grantApprovalService.grantForTouUplift(request.application, request.submission, grantedRequest.gatekeeperUserName)
         .map(_ match {
           case Actioned(application)                  => Ok(Json.toJson(ApplicationResponse(application)))
-          case RejectedDueToIncorrectSubmissionState  => PreconditionFailed(asJsonError("NOT_IN_GRANTED_WITH_WARNINGS_STATE", s"Submission for $applicationId was not in a granted with warnings state"))
+          case RejectedDueToIncorrectSubmissionState  =>
+            PreconditionFailed(asJsonError("NOT_IN_GRANTED_WITH_WARNINGS_STATE", s"Submission for $applicationId was not in a granted with warnings state"))
           case RejectedDueToIncorrectApplicationState =>
             PreconditionFailed(asJsonError("APPLICATION_IN_INCORRECT_STATE", s"Application is not in state '${State.PRODUCTION}'"))
           case RejectedDueToIncorrectApplicationData  => PreconditionFailed(asJsonError("APPLICATION_DATA_IS_INCORRECT", "Application does not have the expected data"))

--- a/app/uk/gov/hmrc/apiplatform/modules/approvals/services/GrantApprovalsService.scala
+++ b/app/uk/gov/hmrc/apiplatform/modules/approvals/services/GrantApprovalsService.scala
@@ -210,15 +210,15 @@ class GrantApprovalsService @Inject() (
     import cats.implicits._
     import cats.instances.future.catsStdInstancesForFuture
 
-    val ET    = EitherTHelper.make[Result]
+    val ET = EitherTHelper.make[Result]
     (
       for {
         _ <- ET.cond(originalApp.isInProduction, (), RejectedDueToIncorrectApplicationState)
         _ <- ET.cond(submission.status.isGrantedWithWarnings, (), RejectedDueToIncorrectSubmissionState)
 
-        updatedSubmission        = Submission.grant(LocalDateTime.now(clock), gatekeeperUserName)(submission)
-        savedSubmission         <- ET.liftF(submissionService.store(updatedSubmission))
-        _                       <- ET.liftF(emailConnector.sendNewTermsOfUseConfirmation(originalApp.name, originalApp.admins.map(_.emailAddress)))
+        updatedSubmission = Submission.grant(LocalDateTime.now(clock), gatekeeperUserName)(submission)
+        savedSubmission  <- ET.liftF(submissionService.store(updatedSubmission))
+        _                <- ET.liftF(emailConnector.sendNewTermsOfUseConfirmation(originalApp.name, originalApp.admins.map(_.emailAddress)))
       } yield Actioned(originalApp)
     )
       .fold[Result](identity, identity)

--- a/app/uk/gov/hmrc/thirdpartyapplication/connector/EmailConnector.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/connector/EmailConnector.scala
@@ -464,7 +464,7 @@ class EmailConnector @Inject() (httpClient: HttpClient, config: EmailConnector.C
         }
     }
 
-    if(payload.to.isEmpty) {
+    if (payload.to.isEmpty) {
       logger.warn(s"Sending email ${payload.templateId} abandoned due to lack of any recipients")
       Future.successful(HasSucceeded)
     } else {

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/ClientSecretService.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/ClientSecretService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.thirdpartyapplication.services
 import java.time.{Instant, ZoneOffset}
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.util.{Failure, Success}
 
 import com.github.t3hnar.bcrypt._

--- a/app/uk/gov/hmrc/thirdpartyapplication/services/commands/CommandHandler.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/services/commands/CommandHandler.scala
@@ -76,7 +76,7 @@ object CommandHandler {
     value.fold(left.invalidNec[R])(_.validNec[CommandFailure])
   }
 
-  def mustBeDefined[R](value: Option[R], left: String): Validated[Failures, R]                                     = {
+  def mustBeDefined[R](value: Option[R], left: String): Validated[Failures, R] = {
     value.fold[Validated[Failures, R]](GenericFailure(left).invalidNec[R])(_.validNec[CommandFailure])
   }
 

--- a/test/uk/gov/hmrc/apiplatform/modules/approvals/services/GrantApprovalsServiceSpec.scala
+++ b/test/uk/gov/hmrc/apiplatform/modules/approvals/services/GrantApprovalsServiceSpec.scala
@@ -75,7 +75,7 @@ class GrantApprovalsServiceSpec extends AsyncHmrcSpec {
       access = Standard(importantSubmissionData = Some(testImportantSubmissionData))
     )
 
-    val prodAppId                              = ApplicationId.random
+    val prodAppId = ApplicationId.random
 
     val applicationProduction: ApplicationData = anApplicationData(
       prodAppId,
@@ -198,7 +198,7 @@ class GrantApprovalsServiceSpec extends AsyncHmrcSpec {
       SubmissionsServiceMock.Store.thenReturn()
       EmailConnectorMock.SendNewTermsOfUseConfirmation.thenReturnSuccess()
 
-      val result      = await(underTest.grantForTouUplift(applicationProduction, grantedWithWarningsSubmission, gatekeeperUserName))
+      val result = await(underTest.grantForTouUplift(applicationProduction, grantedWithWarningsSubmission, gatekeeperUserName))
 
       result should matchPattern {
         case GrantApprovalsService.Actioned(app) =>

--- a/test/uk/gov/hmrc/apiplatform/modules/scheduling/RunningOfScheduledJobsSpec.scala
+++ b/test/uk/gov/hmrc/apiplatform/modules/scheduling/RunningOfScheduledJobsSpec.scala
@@ -31,7 +31,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerTest
 
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.inject.{bind, ApplicationLifecycle}
+import play.api.inject.{ApplicationLifecycle, bind}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 import uk.gov.hmrc.thirdpartyapplication.config.{ClockModule, SchedulerModule}

--- a/test/uk/gov/hmrc/thirdpartyapplication/connector/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartyapplication/connector/EmailConnectorSpec.scala
@@ -25,11 +25,11 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 
 import uk.gov.hmrc.apiplatform.modules.applications.domain.models.ApplicationId
 import uk.gov.hmrc.apiplatform.modules.approvals.domain.models.ResponsibleIndividualVerificationId
+import uk.gov.hmrc.apiplatform.modules.common.domain.models.LaxEmailAddress
 import uk.gov.hmrc.apiplatform.modules.common.domain.models.LaxEmailAddress.StringSyntax
 import uk.gov.hmrc.thirdpartyapplication.connector.EmailConnector.SendEmailRequest
 import uk.gov.hmrc.thirdpartyapplication.models.HasSucceeded
 import uk.gov.hmrc.thirdpartyapplication.util.CollaboratorTestData
-import uk.gov.hmrc.apiplatform.modules.common.domain.models.LaxEmailAddress
 
 class EmailConnectorSpec extends ConnectorSpec with CollaboratorTestData {
 

--- a/test/uk/gov/hmrc/thirdpartyapplication/connector/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/thirdpartyapplication/connector/EmailConnectorSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.apiplatform.modules.common.domain.models.LaxEmailAddress.Stri
 import uk.gov.hmrc.thirdpartyapplication.connector.EmailConnector.SendEmailRequest
 import uk.gov.hmrc.thirdpartyapplication.models.HasSucceeded
 import uk.gov.hmrc.thirdpartyapplication.util.CollaboratorTestData
+import uk.gov.hmrc.apiplatform.modules.common.domain.models.LaxEmailAddress
 
 class EmailConnectorSpec extends ConnectorSpec with CollaboratorTestData {
 
@@ -71,6 +72,22 @@ class EmailConnectorSpec extends ConnectorSpec with CollaboratorTestData {
     val applicationId     = ApplicationId.random
     val developer         = collaboratorEmail.developer()
     val administrator     = adminEmail1.admin()
+
+    "not attempt to do anything if there are no recipients" in new Setup {
+      val expectedTemplateId                      = "apiAddedDeveloperAsCollaboratorConfirmation"
+      val expectedToEmails                        = Set.empty[LaxEmailAddress]
+      val expectedParameters: Map[String, String] = Map(
+        "article"           -> "an",
+        "role"              -> "admin",
+        "applicationName"   -> applicationName,
+        "developerHubTitle" -> hubTestTitle
+      )
+      val expectedRequest                         = SendEmailRequest(expectedToEmails, expectedTemplateId, expectedParameters)
+
+      // No stubbing so we cannot call POST
+
+      await(connector.sendCollaboratorAddedConfirmation(administrator, applicationName, expectedToEmails)) shouldBe HasSucceeded
+    }
 
     "send added collaborator confirmation email" in new Setup {
       val expectedTemplateId                      = "apiAddedDeveloperAsCollaboratorConfirmation"


### PR DESCRIPTION
Whilst we shouldn't get here often without recipients until TPO(t) is in place this could happen with the commands.