### PR TITLE
API-7342 Fix scheduled job for reminder interval in minutes

### DIFF
--- a/app/uk/gov/hmrc/thirdpartyapplication/scheduled/TermsOfUseInvitationReminderJob.scala
+++ b/app/uk/gov/hmrc/thirdpartyapplication/scheduled/TermsOfUseInvitationReminderJob.scala
@@ -72,7 +72,7 @@ class TermsOfUseInvitationReminderJob @Inject() (
           subs.exists(sub => inv.applicationId == sub.applicationId && sub.instances.size == 1)
       )
     }
-    val reminderDueTime: Instant                                                                                 = Instant.now(clock).truncatedTo(MILLIS).plus(termsOfUseInvitationReminderInterval.toDays.toInt, ChronoUnit.DAYS)
+    val reminderDueTime: Instant                                                                                 = Instant.now(clock).truncatedTo(MILLIS).plus(termsOfUseInvitationReminderInterval.toMinutes, ChronoUnit.MINUTES)
     logger.info(s"Send terms of use reminders for invitations having status of EMAIL_SENT with dueBy earlier than $reminderDueTime")
 
     val result: Future[RunningOfJobSuccessful.type] = for {


### PR DESCRIPTION
Fix for issue where the reminder interval is expressed in minutes - in production this value is set to 30 days, but in QA it is set to 5 minutes.